### PR TITLE
[solaris] append mail= to prevent pkgadd sending mail

### DIFF
--- a/views/install.sh.erb
+++ b/views/install.sh.erb
@@ -237,6 +237,7 @@ case "$filetype" in
   "deb") dpkg -i /tmp/$filename ;;
   "solaris") echo "conflict=nocheck" > /tmp/nocheck
 	     echo "action=nocheck" >> /tmp/nocheck
+	     echo "mail=" >> /tmp/nocheck
 	     pkgadd -n -d /tmp/$filename -a /tmp/nocheck chef
 	     ;;
   "sh" ) bash /tmp/$filename ;;


### PR DESCRIPTION
Some installations may not have sendmail installed by default,
resulting in an error such as this when installation completes:

```
Thank you for installing Chef!
exec of "/usr/lib/sendmail" failed: No such file or directory
mail: ERROR signal 13

Installation of <chef> was successful.
```

For example, OmniOS does not install sendmail by default.
