### PR TITLE
Fix crash caused by malformed version numbers

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -173,18 +173,19 @@ class Omnitruck < Sinatra::Base
   # away completely in favor of direct instantiation of an
   # +OpscodeSemVer+ object.
   def janky_workaround_for_processing_all_our_different_version_strings(version_string)
-    v = [
-          Opscode::Version::Rubygems,
-          Opscode::Version::GitDescribe,
-          Opscode::Version::OpscodeSemVer,
-          Opscode::Version::SemVer
-        ].each do |version|
-          begin
-            break version.new(version_string)
-          rescue
-            next nil
-          end
-        end
+    v = nil
+    [
+      Opscode::Version::Rubygems,
+      Opscode::Version::GitDescribe,
+      Opscode::Version::OpscodeSemVer,
+      Opscode::Version::SemVer
+    ].each do |version|
+      begin
+        break v = version.new(version_string)
+      rescue
+        nil
+      end
+    end
 
     if v.nil?
       raise InvalidDownloadPath, "Unsupported version format '#{version_string}'"

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -36,7 +36,7 @@ describe 'Omnitruck' do
       end
 
       it "should serve JSON metadata with a URI for package #{expected_version}" do
-        get(metadata_endpoint, params)
+        get(metadata_endpoint, params, "HTTP_ACCEPT" => "application/json")
         metadata_json = last_response.body
         parsed_json = JSON.parse(metadata_json)
 

--- a/spec/data/build_server_list_v1.json
+++ b/spec/data/build_server_list_v1.json
@@ -2,6 +2,7 @@
   "el": {
     "5": {
       "x86_64": {
+        "": "/el/5/x86_64/chef-server-11.0.8+20130510085727.git.10.115aaf4-1.el5.x86_64.rpm",
         "11.0.0-alpha-10-g642ffed": "/el/5/x86_64/chef-server-11.0.0_alpha_10_g642ffed-1.el5.x86_64.rpm",
         "11.0.0-alpha-12-gdec9c4d": "/el/5/x86_64/chef-server-11.0.0_alpha_12_gdec9c4d-1.el5.x86_64.rpm",
         "11.0.0-alpha-14-ga07db29": "/el/5/x86_64/chef-server-11.0.0_alpha_14_ga07db29-1.el5.x86_64.rpm",

--- a/spec/data/build_server_list_v2.json
+++ b/spec/data/build_server_list_v2.json
@@ -2,6 +2,11 @@
   "el": {
     "5": {
       "x86_64": {
+        "": {
+          "relpath": "/el/5/x86_64/chef-server-11.0.8+20130510085727.git.10.115aaf4-1.el5.x86_64.rpm",
+          "md5": "2d3a4d821041b1b02fa05d169b90dfb4",
+          "sha256": "7d3b64cd108445da532b9411016dc982c4385b8a8ce1baeb10cac6c271242974"
+        },
         "11.0.0-alpha-10-g642ffed": {
           "relpath": "/el/5/x86_64/chef-server-11.0.0_alpha_10_g642ffed-1.el5.x86_64.rpm",
           "md5": "c97287748df333d059af4435db26d33f",


### PR DESCRIPTION
## Stack trace of the crash:

```
NoMethodError - undefined method `release?' for #<Array:0x007ff24a604d68>:
  /Users/ddeleo/oc/opscode-omnitruck/lib/opscode/version.rb:296:in `block in find_target_version'
  /Users/ddeleo/oc/opscode-omnitruck/lib/opscode/version.rb:276:in `select'
```
## Data that causes crash:

``` json
{
  "el": {
    "5": {
      "x86_64": {
        "": "/el/5/x86_64/chef-server-11.0.8+20130510085727.git.10.115aaf4-1.el5.x86_64.rpm",
```
## Bug

The existing code that checks for malformed versions iterates over a list of
version numbering types takes the return value from Array#each, and uses
`break` within the loop to return a single value. When a version string
is not a valid version of any of the types, the variable was set to the
return of `Array#each`, which is the array. The test for
non-matching-ness expected a non-match to return nil.
