### PR TITLE
Added quotes to wget and curl args to address CHEF-4080 (see below).

### DIFF
--- a/views/install.sh.erb
+++ b/views/install.sh.erb
@@ -200,11 +200,11 @@ tmp_dir=$(mktemp -d -t tmp.XXXXXXXX || echo "/tmp")
 if exists wget;
 then
   downloader="wget"
-  wget -O "$tmp_dir/$filename" $url 2>/tmp/stderr
+  wget -O "$tmp_dir/$filename" "$url" 2>/tmp/stderr
 elif exists curl;
 then
   downloader="curl"
-  curl -L $url > "$tmp_dir/$filename"
+  curl -L "$url" > "$tmp_dir/$filename"
 else
   echo "Cannot find wget or curl - cannot install Chef!"
   exit 5


### PR DESCRIPTION
P.S. Could not repro the above issue in bash or dash. If you run $wget some-url-with-& it will break if not quoted; however, if you set the variable url=some-url-with-& then wget $url, it does not need the quote escaping as far as I can tell.

Maybe it was an early bug in dash that was patched later?

http://tickets.opscode.com/browse/CHEF-4080
https://tickets.corp.opscode.com/browse/OC-7393
