### PR TITLE
Add debian 7 to the platform version mangler

### DIFF
--- a/views/install.sh.erb
+++ b/views/install.sh.erb
@@ -168,6 +168,7 @@ case $platform in
     case $major_version in
       "5") platform_version="6";;
       "6") platform_version="6";;
+      "7") platform_version="6";;
     esac
     ;;
   "freebsd")


### PR DESCRIPTION
We're already using the 6.0 package on 5 in this script.

I'm using the 6.0 package on my local Debian 7 system w/o issue.
