### PR TITLE
add support for BSD's `fetch`

### DIFF
--- a/views/install.sh.erb
+++ b/views/install.sh.erb
@@ -260,6 +260,15 @@ do_curl() {
   return 0
 }
 
+# do_fetch URL FILENAME
+do_fetch() {
+  echo "trying fetch..."
+  fetch -o "$2" "$1" 2>/tmp/stderr
+  # check for bad return status
+  test $? -ne 0 && return 1
+  return 0
+}
+
 # do_curl URL FILENAME
 do_perl() {
   echo "trying perl..."
@@ -302,6 +311,10 @@ do_download() {
 
   if exists curl; then
     do_curl $1 $2 && return 0
+  fi
+
+  if exists fetch; then
+    do_fetch $1 $2 && return 0
   fi
 
   if exists perl; then


### PR DESCRIPTION
Fetch exists in the base FreeBSD install which makes it perfect for 
getting Chef onto a system so bootstrapping can proceed.
