### PR TITLE
CHEF-4678: Add OS X 10.9 version hack to install.sh

### DIFF
--- a/views/install.sh.erb
+++ b/views/install.sh.erb
@@ -114,8 +114,7 @@ then
   major_version=$(echo $platform_version | cut -d. -f1,2)
   case $major_version in
     "10.6") platform_version="10.6" ;;
-    "10.7") platform_version="10.7" ;;
-    "10.8") platform_version="10.7" ;;
+    "10.7"|"10.8"|"10.9") platform_version="10.7" ;;
     *) echo "No builds for platform: $major_version"
        report_bug
        exit 1


### PR DESCRIPTION
Opscode's build system presents nice JSON to omnitriuck for the omnitruck API
and the download web page, but we're behind on OS X test infrastructure, so
we keep it hacked for now.
