### PR TITLE
Add better support for caching the omnibus packages

### DIFF
--- a/views/install.sh.erb
+++ b/views/install.sh.erb
@@ -50,16 +50,17 @@ report_bug() {
 }
 
 # Get command line arguments
-while getopts pv:f: opt
+while getopts pv:f:d: opt
 do
   case "$opt" in
 
     v)  version="$OPTARG";;
     p)  prerelease="true";;
     f)  cmdline_filename="$OPTARG";;
+    d)  cmdline_dl_dir="$OPTARG";;
     \?)   # unknown flag
       echo >&2 \
-      "usage: $0 [-p] [-v version] [-f filename]"
+      "usage: $0 [-p] [-v version] [-f filename | -d download_dir]"
       exit 1;;
   esac
 done
@@ -450,10 +451,12 @@ fi
 filename=`echo $download_url | sed -e 's/^.*\///'`
 filetype=`echo $filename | sed -e 's/^.*\.//'`
 
-if test "x$cmdline_filename" = "x"; then
-  download_filename="$tmp_dir/$filename"
-else
+if test "x$cmdline_filename" != "x"; then
   download_filename="$cmdline_filename"
+elif test "x$cmdline_dl_dir" != "x"; then
+  download_filename="$cmdline_dl_dir/$filename"
+else
+  download_filename="$tmp_dir/$filename"
 fi
 
 do_download "$download_url"  "$download_filename"


### PR DESCRIPTION
For caching purposes it's essential to use the real, platform and version specific package name.
- Get filename and type from the downloaded metadata. Earlier for example the `version` was empty by default.
- Allow specifying the download dir instead of full path, as we already get the filename from metadata.
- Drop obsolete `-s/use_shell` command line option. It doesn't make sense to feed distro packages to shell.

Related issues: test-kitchen/test-kitchen#196, schisamo/vagrant-omnibus#22, fgrehm/vagrant-cachier#13

**Disclaimer**: I'm only 37, so I need a careful :eyes: review by the elves and :hammer: testing by dwarfs.
