### PR TITLE
add --replacepkgs to rpm install command

### DIFF
--- a/views/install.sh.erb
+++ b/views/install.sh.erb
@@ -426,7 +426,7 @@ install_file() {
   case "$1" in
     "rpm")
       echo "installing with rpm..."
-      rpm -Uvh --oldpackage "$2"
+      rpm -Uvh --oldpackage --replacepkgs "$2"
       ;;
     "deb")
       echo "installing with dpkg..."


### PR DESCRIPTION
without this rpm will error if the package is already installed.

this was broken for a very long time, but the error checking at the
end of the script had also been broken and we had been ignoring
this error.
