### PR TITLE
Cache omnibus download

### DIFF
--- a/views/install.sh.erb
+++ b/views/install.sh.erb
@@ -471,7 +471,7 @@ md5=`awk '$1 == "md5" { print $2 }' "$metadata_filename"`
 # check if we have that file locally available and if so verify the checksum
 cached_file_available="false"
 if test -f $download_filename; then
-  echo "$filename already exists, verifiying checksum..."
+  echo "$download_filename already exists, verifiying checksum..."
   if do_checksum "$download_filename" "$sha256" "$md5"; then
     echo "checksum compare succeeded, using existing file!"
     cached_file_available="true"


### PR DESCRIPTION
As discussed in fgrehm/vagrant-cachier#13 the `install.sh` script should not download the omnibus package over and over again if the `-d` or `-f` option is used and the file is locally available AND the checksum matches (e.g. when using vagrant-cachier or an nfs mount).

The behaviour is now [as proposed here](https://github.com/fgrehm/vagrant-cachier/issues/13#issuecomment-36106171):
- the metadata file is _always_ downloaded to `$tmp_dir` (which will be removed afterwards)
- if neither `-d` or `-f` are specified the omnibus package is downloaded to `$tmp_dir` as well (i.e. it will also be cleaned up afterwards)
- if `-d` (directory) is specified the omnibus package will be downloaded to that directory with its original filename (as specified in the metadata file). If that file already exists in the given location AND the checksum matches it will just use the already present file instead of downloading again. 
- if `-f` (path to filename) is specified the omnibus package will be downloaded to that file. If a file with that name already exists AND the checksum matches it will just use the already present file instead of downloading again. 

In essence this means that the we will always check the web service for the latest filename / checksums, but allow for caching if either `-d` or `-f` are used.
