### PR TITLE
Fixed: Reset platform_version for XenServer to 5.0, chef-client won't run out-of-the-box cause libc6 is missing

### DIFF
--- a/views/install.sh.erb
+++ b/views/install.sh.erb
@@ -104,13 +104,16 @@ elif test -f "/etc/redhat-release"; then
     # FIXME: remove client side platform_version mangling and hard coded yolo
     # Change platform version for use below.
     platform_version="6.0"
-  elif test "$platform" = "xenserver"; then
-    # FIXME: treat xenserver as own distro?
-    # Current XenServer 6.2 is based on CentOS 5, reset Version to 5
-    platform_version="5.0"
   fi
-  # FIXME: use "redhat"
-  platform="el"
+
+  if test "$platform" = "xenserver"; then
+    # Current XenServer 6.2 is based on CentOS 5, platform is not reset to "el" server should hanlde response
+    platform="xenserver"
+  else
+    # FIXME: use "redhat"
+    platform="el"
+  fi
+  
 elif test -f "/etc/system-release"; then
   platform=`sed 's/^\(.\+\) release.\+/\1/' /etc/system-release | tr '[A-Z]' '[a-z]'`
   platform_version=`sed 's/^.\+ release \([.0-9]\+\).*/\1/' /etc/system-release | tr '[A-Z]' '[a-z]'`


### PR DESCRIPTION
Just tried to install chef through knife bootstrap on some XenServer 6.2 Servers and noticed that Xenserver is treated like RHEL6 because the platform_version is set to 6.2.

Unfortunatly XenServer 6 is based on CentOS 5 and build without libc6, after installation you recieve this error:
/opt/chef/embedded/bin/ruby: /lib/libc.so.6: version `GLIBC_2.6' not found (required by /opt/chef/embedded/lib/libruby.so.1.9)

This PR should fix this behaviour, I hope this is the correct way to contribute. If you want me to add something, drop me a line :D

Cheers,
Jan
