### PR TITLE
Update AIX platform version and arch to match Ohai values

### DIFF
--- a/platforms.rb
+++ b/platforms.rb
@@ -47,9 +47,7 @@ platform "centos" do
   remap "el"
 end
 
-platform "aix" do
-  major_only true
-end
+platform "aix"
 
 # Supported Variants
 #

--- a/views/install.sh.erb
+++ b/views/install.sh.erb
@@ -154,8 +154,8 @@ elif test "x$os" = "xFreeBSD"; then
   platform_version=`uname -r | sed 's/-.*//'`
 elif test "x$os" = "xAIX"; then
   platform="aix"
-  platform_version=`uname -v`
-  machine="ppc"
+  platform_version="${uname -v}.${uname -r}"
+  machine="powerpc"
 fi
 
 if test "x$platform" = "x"; then


### PR DESCRIPTION
The Omnibus framework uses Ohai under the covers to determine the platform, platform version and architecture which is used in the generated *.metadata.json. This metadata is also fed into Omnitruck so install.sh should use the same values for filtering.

/cc @opscode/release-engineers @opscode/client-engineers @opscode/field-solution-engineers 
