### PR TITLE
Fix ancient shell substitution on AIX & support BFFs

### DIFF
--- a/views/install.sh.erb
+++ b/views/install.sh.erb
@@ -436,7 +436,7 @@ do_download() {
 }
 
 # install_file TYPE FILENAME
-# TYPE is "rpm", "deb", "solaris", or "sh"
+# TYPE is "rpm", "deb", "solaris", "sh", etc.
 install_file() {
   echo "Installing Chef $version"
   case "$1" in
@@ -447,6 +447,10 @@ install_file() {
     "deb")
       echo "installing with dpkg..."
       dpkg -i "$2"
+      ;;
+    "bff")
+      echo "installing with installp..."
+      installp -aXYgd "$2" all
       ;;
     "solaris")
       echo "installing with pkgadd..."


### PR DESCRIPTION
AIX's `sh` is too old to do the kind of trickery in #49 . Instead you'll get:

``` text
install.sh[172]: platform_version="${uname -v}.${uname -r}": 0403-011 The specified substitution is not valid for this command.
```

Also, added support for installing `bff`s
