### PR TITLE
Fix #102 - support /etc/os-release as fallback option in install.sh.

### DIFF
--- a/views/install.sh.erb
+++ b/views/install.sh.erb
@@ -171,6 +171,13 @@ elif test "x$os" = "xAIX"; then
   platform="aix"
   platform_version="`uname -v`.`uname -r`"
   machine="powerpc"
+elif test -f "/etc/os-release"; then
+  . /etc/os-release
+  platform=$ID
+  if test "x$platform" = "x"; then
+    platform="linux"
+  fi
+  platform_version=$VERSION_ID
 fi
 
 if test "x$platform" = "x"; then

--- a/views/install.sh.erb
+++ b/views/install.sh.erb
@@ -173,14 +173,10 @@ elif test "x$os" = "xAIX"; then
   machine="powerpc"
 elif test -f "/etc/os-release"; then
   . /etc/os-release
-  if test "x$ID_LIKE" != "x"; then
-    case $ID_LIKE in
-      "cisco-wrlinux")
-        platform="cisco-wrlinux"
-        # 3.4.43-WR5.0.1.13_standard  -->  5
-        platform_version=`uname -r | sed 's/.*-WR\([0-9]\+\).*/\1/'`
-        ;;
-    esac
+  if test "x$ID_LIKE" = "xwrlinux" || test "x$ID_LIKE" = "xcisco-wrlinux"; then
+    platform="wrlinux"
+    # 3.4.43-WR5.0.1.13_standard  -->  5
+    platform_version=`uname -r | sed 's/.*-WR\([0-9]\+\).*/\1/'`
   fi
 fi
 
@@ -452,7 +448,7 @@ install_file() {
   echo "Installing Chef $version"
   case "$1" in
     "rpm")
-      if test "x$platform" = "xcisco-wrlinux"; then
+      if test "x$platform" = "xwrlinux"; then
         echo "installing with yum..."
         yum install -yv "$2"
       else

--- a/views/install.sh.erb
+++ b/views/install.sh.erb
@@ -173,11 +173,15 @@ elif test "x$os" = "xAIX"; then
   machine="powerpc"
 elif test -f "/etc/os-release"; then
   . /etc/os-release
-  platform=$ID
-  if test "x$platform" = "x"; then
-    platform="linux"
+  if test "x$ID_LIKE" != "x"; then
+    case $ID_LIKE in
+      "cisco-wrlinux")
+        platform="cisco-wrlinux"
+        # 3.4.43-WR5.0.1.13_standard  -->  5
+        platform_version=`uname -r | sed 's/.*-WR\([0-9]\+\).*/\1/'`
+        ;;
+    esac
   fi
-  platform_version=$VERSION_ID
 fi
 
 if test "x$platform" = "x"; then
@@ -448,8 +452,13 @@ install_file() {
   echo "Installing Chef $version"
   case "$1" in
     "rpm")
-      echo "installing with rpm..."
-      rpm -Uvh --oldpackage --replacepkgs "$2"
+      if test "x$platform" = "xcisco-wrlinux"; then
+        echo "installing with yum..."
+        yum install -yv "$2"
+      else
+        echo "installing with rpm..."
+        rpm -Uvh --oldpackage --replacepkgs "$2"
+      fi
       ;;
     "deb")
       echo "installing with dpkg..."


### PR DESCRIPTION
We have a Linux-based platform that only provides its platform info in `/etc/os-release` and not in any of the other historical `/etc/foo-release` files. Extend install.sh to recognize this source of information.
