### PR TITLE
Silence the install warning on CI systems.

### DIFF
--- a/views/install.sh.erb
+++ b/views/install.sh.erb
@@ -580,7 +580,7 @@ if test "x$cached_file_available" != "xtrue"; then
   do_checksum "$download_filename" "$sha256" "$md5" || checksum_mismatch
 fi
 
-if test "x$version" = "x"; then
+if test "x$version" = "x" -a "x$CI" != "xtrue"; then
   echo
   echo "WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING"
   echo


### PR DESCRIPTION
Given that CI is one of the mentioned exceptions, it would be nice if my build logs didn't have scary things.

I think that syntax should be of the ancients but I defer to a higher authority.
