### PR TITLE
Copy edit some of the warnings to make them more user friendly.

### DIFF
--- a/views/install.sh.erb
+++ b/views/install.sh.erb
@@ -46,12 +46,11 @@ exists() {
 report_bug() {
   echo "Version: $version"
   echo ""
-  echo "Please file a Bug Report at https://github.com/opscode/opscode-omnitruck/issues/new"
-  echo "Alternatively, feel free to open a Support Ticket at https://www.getchef.com/support/tickets"
-  echo "More Chef support resources can be found at https://www.getchef.com/support"
+  echo "Please open a support ticket at https://www.chef.io/support/tickets"
+  echo "More Chef support resources can be found at https://www.chef.io/support"
   echo ""
-  echo "Please include as many details about the problem as possible i.e., how to reproduce"
-  echo "the problem (if possible), type of the Operating System and its version, etc.,"
+  echo "Include as many details about the problem as possible i.e., how to reproduce"
+  echo "the problem (if possible), type of the operating system and its version,"
   echo "and any other relevant details that might help us with troubleshooting."
   echo ""
 }
@@ -584,7 +583,7 @@ if test "x$version" = "x"; then
   echo
   echo "WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING"
   echo
-  echo "You are installing an omnibus package without a version pin.  If you are installing"
+  echo "You are installing a package without specifying a version.  If you are installing"
   echo "on production servers via an automated process this is DANGEROUS and you will"
   echo "be upgraded without warning on new releases, even to new major releases."
   echo "Letting the version float is only appropriate in desktop, test, development or"


### PR DESCRIPTION
I've copy-edited some of this copy to clean it up:
- Point users at support if they encounter a critical omnitruck error. There's too many options here and throwing them at GitHub issues is the deep end
- Remove references to "Omnibus package" and "version pin" -- this is jargon that confuses folks and obscures the meaning.
