### PR TITLE
Workaround ARM package issues on Fedora ARM.

### DIFF
--- a/views/install.sh.erb
+++ b/views/install.sh.erb
@@ -112,8 +112,6 @@ elif test -f "/etc/redhat-release"; then
 
   # If /etc/redhat-release exists, we act like RHEL by default
   if test "$platform" = "fedora"; then
-    # FIXME: stop remapping fedora to el
-    # FIXME: remove client side platform_version mangling and hard coded yolo
     # Change platform version for use below.
     platform_version="6.0"
   fi
@@ -121,9 +119,6 @@ elif test -f "/etc/redhat-release"; then
   if test "$platform" = "xenserver"; then
     # Current XenServer 6.2 is based on CentOS 5, platform is not reset to "el" server should hanlde response
     platform="xenserver"
-  else
-    # FIXME: use "redhat"
-    platform="el"
   fi
 
 elif test -f "/etc/system-release"; then
@@ -445,7 +440,7 @@ install_file() {
       rpmcmd="rpm -Uvh --oldpackage --replacepkgs"
       # RPM Arch is evaluated incorrectly on some
       # RPM based distros for armv7.
-      if test "$machine" == "armv7l" ; then
+      if test "$machine" == "armv7l" -a "$platform" == "fedora" ; then
         rpmcmd="$rpmcmd --ignorearch"
       fi
       $rpmcmd "$2"

--- a/views/install.sh.erb
+++ b/views/install.sh.erb
@@ -442,7 +442,13 @@ install_file() {
   case "$1" in
     "rpm")
       echo "installing with rpm..."
-      rpm -Uvh --oldpackage --replacepkgs "$2"
+      rpmcmd="rpm -Uvh --oldpackage --replacepkgs"
+      # RPM Arch is evaluated incorrectly on some
+      # RPM based distros for armv7.
+      if test "$machine" == "armv7l" ; then
+        rpmcmd="$rpmcmd --ignorearch"
+      fi
+      $rpmcmd "$2"
       ;;
     "deb")
       echo "installing with dpkg..."


### PR DESCRIPTION
While the rpm itself is genated on Fedora, the resulting RPM cannot be installed as rpm complains about the arch. Interestingly enough, attempting to change the arch to what RPM expects when attempting to build the omnibus RPM results in rpmbuild complaining that armv7hl, the expected arch, is an invalid architecture. This issue really only occurs on Fedora (that I know about), as the RPM installs without any changes on OpenSUSE perfectly fine,

While this is not the ideal solution, I do not beleive ohai is incorrect in the result it obtains for the architecture. As such, this issue seems to be isolated to just installing the omnibus
packages.

Closes #120