### PR TITLE
Prioritize application/json over text/plain when responding from metadata endpoint.

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -100,10 +100,10 @@ class Omnitruck < Sinatra::Base
 
     package_info = get_package_info(project, JSON.parse(File.read(project.build_list_path)))
     decorate_url!(package_info)
-    if request.accept? 'text/plain'
-      parse_plain_text(package_info)
-    else
+    if request.accept? 'application/json'
       JSON.pretty_generate(package_info)
+    else
+      parse_plain_text(package_info)
     end
   end
 

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -829,7 +829,7 @@ context 'Omnitruck' do
         let(:endpoint) { legacy_endpoint }
 
         it "returns the correct response data" do
-          get(endpoint, params)
+          get(endpoint, params, "HTTP_ACCEPT" => "text/plain")
 
           if legacy_endpoint =~ /download/
             follow_redirect!


### PR DESCRIPTION
@schisamo @patrick-wright I believe this will handle the case where we are getting plain/text even though we are explicitly calling for application/json.