### PR TITLE
Continue to default to plain text

### DIFF
--- a/.delivery/build-cookbook/recipes/provision.rb
+++ b/.delivery/build-cookbook/recipes/provision.rb
@@ -181,7 +181,7 @@ end
 fastly_request_setting 'cache_key' do
   api_key fastly_creds['api_key']
   service fastly_service.name
-  hash_keys 'req.url, req.http.host, req.http.Fastly-SSL'
+  hash_keys 'req.url, req.http.host, req.http.Fastly-SSL, req.http.accept'
   sensitive true
   notifies :activate_latest, "fastly_service[#{fqdn}]", :delayed
 end

--- a/app.rb
+++ b/app.rb
@@ -100,10 +100,10 @@ class Omnitruck < Sinatra::Base
 
     package_info = get_package_info(project, JSON.parse(File.read(project.build_list_path)))
     decorate_url!(package_info)
-    if request.accept? 'application/json'
-      JSON.pretty_generate(package_info)
-    else
+    if request.accept? 'text/plain'
       parse_plain_text(package_info)
+    else
+      JSON.pretty_generate(package_info)
     end
   end
 

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -829,7 +829,7 @@ context 'Omnitruck' do
         let(:endpoint) { legacy_endpoint }
 
         it "returns the correct response data" do
-          get(endpoint, params, "HTTP_ACCEPT" => "text/plain")
+          get(endpoint, params)
 
           if legacy_endpoint =~ /download/
             follow_redirect!


### PR DESCRIPTION
This commit is being reverted because the change from returning txt
by default to json by default is a breaking one. Currently, install.sh
is broken.

As an example
```
➜  curl "https://omnitruck.chef.io/stable/chef/metadata?p=mac_os_x&pv=10.11&m=x86_64" -vv
*   Trying 199.27.76.65...
* Connected to omnitruck.chef.io (199.27.76.65) port 443 (#0)
* TLS 1.2 connection using TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
* Server certificate: g.ssl.fastly.net
* Server certificate: GlobalSign Organization Validation CA - SHA256 - G2
* Server certificate: GlobalSign Root CA
> GET /stable/chef/metadata?p=mac_os_x&pv=10.11&m=x86_64 HTTP/1.1
> Host: omnitruck.chef.io
> User-Agent: curl/7.43.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Content-Type: text/html;charset=utf-8
< Server: nginx/1.4.6 (Ubuntu)
< Status: 200 OK
< X-Content-Type-Options: nosniff
< X-Frame-Options: SAMEORIGIN
< X-XSS-Protection: 1; mode=block
< Content-Length: 308
< Accept-Ranges: bytes
< Date: Sat, 10 Oct 2015 17:20:11 GMT
< Via: 1.1 varnish
< Age: 0
< Connection: keep-alive
< X-Served-By: cache-jfk1035-JFK
< X-Cache: MISS
< X-Cache-Hits: 0
<
{
  "relpath": "/mac_os_x/10.11/x86_64/chef-12.5.1-1.dmg",
  "md5": "a67fc6a59f463f1d2d7cb38a317c531b",
  "sha256": "98e7d314552ee5e55af7e7b07f90ddf95c1a69d94659e71844d435defb38b3aa",
  "version": "12.5.1",
  "url": "http://opscode-omnibus-packages.s3.amazonaws.com/mac_os_x/10.11/x86_64/chef-12.5.1-1.dmg"
* Connection #0 to host omnitruck.chef.io left intact
}
```

The bash script does not know how to parse json and was expecting txt,
and this fails.