### PR TITLE
Add a newline at the end of the metadata download

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -268,6 +268,6 @@ class Omnitruck < Sinatra::Base
   # parses package_info hash into plaintext string
   def parse_plain_text(package_info)
     full_url = convert_relpath_to_url(package_info["relpath"])
-    "url\t#{full_url}\nmd5\t#{package_info['md5']}\nsha256\t#{package_info['sha256']}\nversion\t#{package_info['version']}"
+    "url\t#{full_url}\nmd5\t#{package_info['md5']}\nsha256\t#{package_info['sha256']}\nversion\t#{package_info['version']}\n"
   end
 end


### PR DESCRIPTION
Currently, the `install.sh` script has ill-formatted output:

```
trying wget...
url https://opscode-omnibus-packages.s3.amazonaws.com/el/7/x86_64/chefdk-0.9.0-1.el7.x86_64.rpm
md5 a5163b300c4ee4abda28d3091d896ba2
sha256  8df4ad12298d1d525d0defaee366f6d4fef56ad68f1e3a6daa7df91f680acb78
version 0.9.0downloaded metadata file looks valid...
```

The last line there is concatenated because the metadata file has no newline. While the script could be fixed instead of the server, the script is more delicate. Adding a newline to the end of the file will resolve the issue.
