### PR TITLE
Prefer curl to wget due to no_proxy support

### DIFF
--- a/views/install.sh.erb
+++ b/views/install.sh.erb
@@ -410,12 +410,12 @@ do_download() {
   # we try all of these until we get success.
   # perl, in particular may be present but LWP::Simple may not be installed
 
-  if exists wget; then
-    do_wget $1 $2 && return 0
-  fi
-
   if exists curl; then
     do_curl $1 $2 && return 0
+  fi
+
+  if exists wget; then
+    do_wget $1 $2 && return 0
   fi
 
   if exists fetch; then


### PR DESCRIPTION
curl supports no_proxy; wget does not. This switches the order we detect them in so that a few more systems will be able to do what they need to do.
