### PR TITLE
Legacy install.msi call should return 32-bit

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -109,11 +109,13 @@ class Omnitruck < Sinatra::Base
   end
 
   get '/chef/install.msi' do
-    redirect to('/stable/chef/download?p=windows&pv=2008r2&m=x86_64')
+    # default to 32-bit architecture for now
+    redirect to('/stable/chef/download?p=windows&pv=2008r2&m=i386')
   end
 
   get '/install.msi' do
-    redirect to('/stable/chef/download?p=windows&pv=2008r2&m=x86_64')
+    # default to 32-bit architecture for now
+    redirect to('/stable/chef/download?p=windows&pv=2008r2&m=i386')
   end
 
   get "/full_:project\\_list" do

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -1006,8 +1006,8 @@ context 'Omnitruck' do
         md5: 'd07cf230410b55bd8939ab29d65a3cc5',
         version: '11.1.6'
       },
-      '/chef/install.msi' => 'http://example.org/stable/chef/download?p=windows&pv=2008r2&m=x86_64',
-      '/install.msi' => 'http://example.org/stable/chef/download?p=windows&pv=2008r2&m=x86_64',
+      '/chef/install.msi' => 'http://example.org/stable/chef/download?p=windows&pv=2008r2&m=i386',
+      '/install.msi' => 'http://example.org/stable/chef/download?p=windows&pv=2008r2&m=i386',
       '/full_client_list' => nil,
       '/full_list' => nil,
       '/full_server_list' => nil,


### PR DESCRIPTION
As we get ready to GA the 64-bit Windows chef client, we need to ensure that the legacy calls work as they have before (ie, return 32-bit architecture).

@chef/engineering-services @schisamo @tyler-ball