### PR TITLE
Update Gemfile and Gemfile.lock.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,6 @@
 source 'https://rubygems.org'
 
-# tracking master because of this bug:
-# https://github.com/sinatra/sinatra/pull/805
-# once 1.4.5 is released, this should stop
-gem 'sinatra', :git => 'https://github.com/sinatra/sinatra.git', :branch => 'master'
+gem 'sinatra', '~> 1.4.7'
 gem 'sinatra-contrib'
 gem 'unicorn'
 gem 'json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,16 +8,6 @@ GIT
       mixlib-shellout
       mixlib-versioning
 
-GIT
-  remote: https://github.com/sinatra/sinatra.git
-  revision: 8035f839fd8a63fd3791c901cf5ed09617e72e13
-  branch: master
-  specs:
-    sinatra (1.4.6)
-      rack (~> 1.5, >= 1.5.4, < 1.6)
-      rack-protection (~> 1.4)
-      tilt (>= 1.3, < 3)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -74,6 +64,10 @@ GEM
     rspec_junit_formatter (0.2.3)
       builder (< 4)
       rspec-core (>= 2, < 4, != 2.12.0)
+    sinatra (1.4.7)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
     sinatra-contrib (1.4.6)
       backports (>= 2.0)
       multi_json
@@ -112,7 +106,7 @@ DEPENDENCIES
   rspec-legacy_formatters
   rspec-rerun (~> 0.3.0)
   rspec_junit_formatter
-  sinatra!
+  sinatra (~> 1.4.7)
   sinatra-contrib
   trashed
   unicorn


### PR DESCRIPTION
This removes the Git references from the Gemfile and Gemfile.lock in favor of using released versions.

Fixes chef/omnitruck#179.