### PR TITLE
Add cumulus linux 3.0.0 (debian jessie) to remap

### DIFF
--- a/platforms.rb
+++ b/platforms.rb
@@ -151,6 +151,16 @@ platform "cumulus networks" do
   version_remap 7
 end
 
+# cumulus linux 3.0.0 and later is debian 8
+platform "cumulus linux" do
+  remap "debian"
+  if version.split('.')[0].to_i >= 3
+      version_remap 8
+  else
+      version_remap 7
+  end
+end
+
 # these are unsupported because we have no build infrastructure for them:
 # - slackware
 # - arch


### PR DESCRIPTION
Since Cumulus 2.3, our lsb platform is now cumulus linux instead of cumulus networks. This PR incorporates that change, as well as our shift to Jessie in 3.0.0.

Let me know if there's anything further I need to do or a different way to get this incorporated.