### PR TITLE
Map Arista EOS to el6 packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Supported parameters are:
 
 The values that `p`, `pv` & `m` can take include but are not limited to:
 
-`p` => "aix", "debian", "el", "freebsd", "ios_xr", "mac_os_x", "nexus", "solaris2", "ubuntu", "windows", "solaris", "sles", "suse"
+`p` => "aix", "debian", "el", "freebsd", "ios_xr", "mac_os_x", "nexus", "solaris2", "ubuntu", "windows", "solaris", "sles", "suse", “arista_eos”
 
 `pv` => `MAJOR.MINOR` version of the platform. E.g. "6.1", "7.1" for "aix", "6", "7", "8" for debian. For windows "2008r2"
 

--- a/platforms.rb
+++ b/platforms.rb
@@ -151,6 +151,12 @@ platform "cumulus networks" do
   version_remap 7
 end
 
+platform "arista_eos" do
+  major_only true
+  remap "el"
+  version_remap 6
+end
+
 # these are unsupported because we have no build infrastructure for them:
 # - slackware
 # - arch


### PR DESCRIPTION
This ensures that the el6 i386 Chef RPM gets selected on Arista EOS platforms as discussed with @jjasghar 
