### PR TITLE
Delivery master sync

### DIFF
--- a/.delivery/build-cookbook/recipes/publish.rb
+++ b/.delivery/build-cookbook/recipes/publish.rb
@@ -28,6 +28,7 @@ end
     origin origin
     plan_dir ::File.join(habitat_plan_dir, pkg)
     home_dir delivery_workspace
+    cwd node['delivery']['workspace']['repo']
     auth_token project_secrets['habitat']['depot_token']
     url node['habitat-build']['depot-url']
     only_if { habitat_depot_token? }


### PR DESCRIPTION
We had a failure in publish, which means that Github master is out of sync and we can't force push because that's bad and we'd feel bad! 

So let's do it this way. It's probably fine.