### PR TITLE
rename the origin variable because origin is a property

### DIFF
--- a/.delivery/build-cookbook/recipes/publish.rb
+++ b/.delivery/build-cookbook/recipes/publish.rb
@@ -16,16 +16,16 @@ include_recipe 'delivery-truck::publish'
 return unless changed_habitat_files?
 
 project_secrets = get_project_secrets
-origin = 'delivery'
+_origin = 'delivery'
 
 if habitat_origin_key?
   keyname = project_secrets['habitat']['keyname']
-  origin = keyname.split('-')[0...-1].join('-')
+  _origin = keyname.split('-')[0...-1].join('-')
 end
 
 %w{omnitruck omnitruck-unicorn-proxy}.each do |pkg|
   hab_build pkg do
-    origin origin
+    origin _origin
     plan_dir ::File.join(habitat_plan_dir, pkg)
     home_dir delivery_workspace
     cwd node['delivery']['workspace']['repo']


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Joshua Timberman

Just for clarity's sake, we don't want to confuse the `origin`
property in the `hab_build` resource with the `origin` local variable,
so it has become `_origin`.

Signed-off-by: Joshua Timberman <joshua@chef.io>



Ready to merge? View this change in Chef Automate and click the Approve button: https://delivery.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/c4c6aae7-3af4-417b-a9b5-451bf5e634ab