### PR TITLE
use lazy{} for unit content because hab isn't installed

### DIFF
--- a/cookbooks/omnitruck/metadata.rb
+++ b/cookbooks/omnitruck/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache2'
 description 'Installs/Configures omnitruck'
 long_description 'Installs/Configures omnitruck'
-version '0.3.1'
+version '0.3.2'
 
 depends 'brightbox-ruby', '~> 1.2'
 depends 'runit', '~> 1.7'

--- a/cookbooks/omnitruck/recipes/default.rb
+++ b/cookbooks/omnitruck/recipes/default.rb
@@ -39,7 +39,7 @@ hab_service 'chef-es/omnitruck' do
 end
 
 hab_service 'chef-es/omnitruck-unicorn-proxy' do
-  unit_content(
+  unit_content(lazy {
     {
       Unit: {
         Description: 'Nginx proxy for Unicorn',
@@ -51,7 +51,7 @@ hab_service 'chef-es/omnitruck-unicorn-proxy' do
         Restart: "on-failure"
       }
     }
-  )
+    })
   action [:enable, :start]
 end
 


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Joshua Timberman

Signed-off-by: Joshua Timberman <joshua@chef.io>



Ready to merge? View this change in Chef Automate and click the Approve button: https://delivery.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/bcc29a11-b298-44c5-b703-5da3abc40490