### PR TITLE
Use Ubuntu 16.04 for systemd

### DIFF
--- a/.delivery/build-cookbook/attributes/default.rb
+++ b/.delivery/build-cookbook/attributes/default.rb
@@ -1,0 +1,3 @@
+# Change the default AMI to Ubuntu 16.04 so we can properly use
+# systemd for habitat's services.
+default['ciainfra']['image_id'] = 'ami-7ac6491a'

--- a/cookbooks/omnitruck/.kitchen.yml
+++ b/cookbooks/omnitruck/.kitchen.yml
@@ -6,7 +6,7 @@ provisioner:
   name: chef_zero
 
 platforms:
-  - name: ubuntu-14.04
+  - name: ubuntu-16.04
 
 suites:
   - name: default


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Joshua Timberman

The hab_service resource only supports systemd at this time, so we
need to update our AMIs to be Ubuntu 16.04 which uses systemd as PID 1
instead of Upstart.

Acceptance nodes need to be deleted, as do the URD nodes once
Acceptance is working.

Signed-off-by: Joshua Timberman <joshua@chef.io>



Ready to merge? View this change in Chef Automate and click the Approve button: https://delivery.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/fe34244a-b690-4a73-8b32-2b492b2b35f8