### PR TITLE
specify the security group via attribute

### DIFF
--- a/.delivery/build-cookbook/attributes/default.rb
+++ b/.delivery/build-cookbook/attributes/default.rb
@@ -1,3 +1,4 @@
 # Change the default AMI to Ubuntu 16.04 so we can properly use
 # systemd for habitat's services.
 default['ciainfra']['image_id'] = 'ami-7ac6491a'
+default['ciainfra']['security_groups'] = ['sg-9d9223f9']


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Joshua Timberman

For some reason the CIAInfra helper isn't picking up the security
group, so let's set it in an attribute.

Signed-off-by: Joshua Timberman <joshua@chef.io>



Ready to merge? View this change in Chef Automate and click the Approve button: https://delivery.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/0d1129d4-88fc-4c7a-a28a-5dfcb8ad07a5