### PR TITLE
ensure application files are readable by non-root users

### DIFF
--- a/habitat/omnitruck/plan.sh
+++ b/habitat/omnitruck/plan.sh
@@ -79,6 +79,8 @@ do_build() {
 
 do_install() {
   cp -R . "${pkg_prefix}/static"
+  # sometimes gem authors commit and release files that aren't "other" readable.
+  find ${pkg_prefix}/static -not -perm -o+r -exec chmod o+r {} \;
 
   for binstub in ${pkg_prefix}/static/bin/*; do
     build_line "Setting shebang for ${binstub} to 'ruby'"


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Joshua Timberman

Sometimes, gems get released with 0640 permissions, which happened
with the statsd gem v 1.2.1 (.gitignore). Because the application runs
as `hab`, it doesn't have permission to copy this file to the static
directory in the init hook. This change finds all files that don't
have "other read" and changes the permission to allow that.

Signed-off-by: Joshua Timberman <joshua@chef.io>



Ready to merge? View this change in Chef Automate and click the Approve button: https://delivery.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/98662e9c-ed44-452e-90b4-26e6109a0573