### PR TITLE
render content for omnitruck service to set HOME

### DIFF
--- a/cookbooks/omnitruck/metadata.rb
+++ b/cookbooks/omnitruck/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache2'
 description 'Installs/Configures omnitruck'
 long_description 'Installs/Configures omnitruck'
-version '0.3.5'
+version '0.3.6'
 
 depends 'brightbox-ruby', '~> 1.2'
 depends 'runit', '~> 1.7'

--- a/cookbooks/omnitruck/recipes/default.rb
+++ b/cookbooks/omnitruck/recipes/default.rb
@@ -35,6 +35,22 @@ hab_package 'chef-es/omnitruck-unicorn-proxy' do
 end
 
 hab_service 'chef-es/omnitruck' do
+  unit_content(lazy {
+    {
+      Unit: {
+        Description: 'omnitruck',
+        After: 'network.target audit.service omnitruck.service'
+      },
+      Service: {
+        Environment: [
+          "SSL_CERT_FILE=#{hab('pkg', 'path', 'core/cacerts').stdout.chomp}/ssl/cert.pem",
+          "HOME=/hab"
+        ],
+        ExecStart: "/bin/hab start chef-es/omnitruck",
+        Restart: "on-failure"
+      }
+    }
+    })
   action [:enable, :start]
 end
 


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Joshua Timberman

We need to customize the `unit_content` for the omnitruck service
beyond what the `hab_service_systemd` provider allows. In this case,
we need to set the `HOME` variable for ruby's libreadline. We don't
really know *why* readline needs a HOME, but here we are.

Signed-off-by: Joshua Timberman <joshua@chef.io>



Ready to merge? View this change in Chef Automate and click the Approve button: https://delivery.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/1beedef8-6308-41b9-b95c-61eb4c3017f8