### PR TITLE
Removes guard

### DIFF
--- a/.delivery/build-cookbook/recipes/publish.rb
+++ b/.delivery/build-cookbook/recipes/publish.rb
@@ -13,8 +13,6 @@ include_recipe 'delivery-truck::publish'
 # custom publish steps instead of using `habitat-build::publish`,
 # because we're multipackage.
 
-return unless changed_habitat_files?
-
 project_secrets = get_project_secrets
 _origin = 'delivery'
 


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Christopher Webber

The assumption the removed call makes is that we would change a habitat
file each time we push through a change. Since the version is generated
dynamically, there really should be no reason to modify those files. In
the case of the application going through the pipeline, we should always
be building a new hart since it is the entire purpose of the pipeline.

Signed-off-by: Christopher Webber <cwebber@chef.io>



Ready to merge? View this change in Chef Automate and click the Approve button: https://delivery.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/ecf9186b-ce29-43db-bc19-cf890aee4408