### PR TITLE
Disables the ELB reconfiguration

### DIFF
--- a/.delivery/build-cookbook/recipes/provision.rb
+++ b/.delivery/build-cookbook/recipes/provision.rb
@@ -78,48 +78,48 @@ machine_batch do
   end
 end
 
-load_balancer "#{instance_name}-elb" do
-  load_balancer_options \
-    listeners: [{
-      port: 80,
-      protocol: :http,
-      instance_port: 80,
-      instance_protocol: :http
-    },
-    {
-      port: 443,
-      protocol: :https,
-      instance_port: 80,
-      instance_protocol: :http,
-      server_certificate: CIAInfra.cert_arn
-    }],
-    subnets: subnets,
-    security_groups: CIAInfra.security_groups(node, 'us-west-2'),
-    scheme: 'internet-facing'
-  machines instances
-end
-
-client = AWS::ELB.new(region: 'us-west-2')
-
-route53_record origin_fqdn do
-  name "#{origin_fqdn}."
-  value lazy { client.load_balancers["#{instance_name}-elb"].dns_name }
-  aws_access_key_id aws_creds['access_key_id']
-  aws_secret_access_key aws_creds['secret_access_key']
-  type 'CNAME'
-  zone_id aws_creds['route53'][domain_name]
-  sensitive true
-end
-
-route53_record direct_fqdn do
-  name "#{direct_fqdn}."
-  value lazy { client.load_balancers["#{instance_name}-elb"].dns_name }
-  aws_access_key_id aws_creds['access_key_id']
-  aws_secret_access_key aws_creds['secret_access_key']
-  type 'CNAME'
-  zone_id aws_creds['route53'][domain_name]
-  sensitive true
-end
+#load_balancer "#{instance_name}-elb" do
+#  load_balancer_options \
+#    listeners: [{
+#      port: 80,
+#      protocol: :http,
+#      instance_port: 80,
+#      instance_protocol: :http
+#    },
+#    {
+#      port: 443,
+#      protocol: :https,
+#      instance_port: 80,
+#      instance_protocol: :http,
+#      server_certificate: CIAInfra.cert_arn
+#    }],
+#    subnets: subnets,
+#    security_groups: CIAInfra.security_groups(node, 'us-west-2'),
+#    scheme: 'internet-facing'
+#  machines instances
+#end
+#
+#client = AWS::ELB.new(region: 'us-west-2')
+#
+#route53_record origin_fqdn do
+#  name "#{origin_fqdn}."
+#  value lazy { client.load_balancers["#{instance_name}-elb"].dns_name }
+#  aws_access_key_id aws_creds['access_key_id']
+#  aws_secret_access_key aws_creds['secret_access_key']
+#  type 'CNAME'
+#  zone_id aws_creds['route53'][domain_name]
+#  sensitive true
+#end
+#
+#route53_record direct_fqdn do
+#  name "#{direct_fqdn}."
+#  value lazy { client.load_balancers["#{instance_name}-elb"].dns_name }
+#  aws_access_key_id aws_creds['access_key_id']
+#  aws_secret_access_key aws_creds['secret_access_key']
+#  type 'CNAME'
+#  zone_id aws_creds['route53'][domain_name]
+#  sensitive true
+#end
 
 ### Fastly Setup
 fastly_service = fastly_service fqdn do


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Christopher Webber

In order to add the new nodes to the mix without putting them directy
in production, we are going to disable updating the ELB until we are
happy with the new nodes. The new nodes in this case are the habitized
versions of omnitruck.

Signed-off-by: Christopher Webber <cwebber@chef.io>



Ready to merge? View this change in Chef Automate and click the Approve button: https://delivery.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/0d3203e9-3b0a-4f21-a009-a46ae84f8d96