### PR TITLE
remove machine_batch for now

### DIFF
--- a/.delivery/build-cookbook/recipes/provision.rb
+++ b/.delivery/build-cookbook/recipes/provision.rb
@@ -60,22 +60,20 @@ direct_fqdn = "#{instance_name}-direct.#{domain_name}"
 subnets = []
 instances = []
 
-machine_batch do
-  1.upto(instance_quantity) do |i|
-    machine "#{instance_name}-#{i}" do
-      action :setup
-      chef_environment delivery_environment
-      attribute 'delivery_org', node['delivery']['change']['organization']
-      attribute 'project', node['delivery']['change']['project']
-      tags node['delivery']['change']['organization'], node['delivery']['change']['project']
-      machine_options CIAInfra.machine_options(node, 'us-west-2', i)
-      files '/etc/chef/encrypted_data_bag_secret' => '/etc/chef/encrypted_data_bag_secret'
-      converge false
-    end
-
-    subnets << CIAInfra.subnet_id(node, CIAInfra.availability_zone('us-west-2', i))
-    instances << "#{instance_name}-#{i}"
+1.upto(instance_quantity) do |i|
+  machine "#{instance_name}-#{i}" do
+    action :setup
+    chef_environment delivery_environment
+    attribute 'delivery_org', node['delivery']['change']['organization']
+    attribute 'project', node['delivery']['change']['project']
+    tags node['delivery']['change']['organization'], node['delivery']['change']['project']
+    machine_options CIAInfra.machine_options(node, 'us-west-2', i)
+    files '/etc/chef/encrypted_data_bag_secret' => '/etc/chef/encrypted_data_bag_secret'
+    converge false
   end
+
+  subnets << CIAInfra.subnet_id(node, CIAInfra.availability_zone('us-west-2', i))
+  instances << "#{instance_name}-#{i}"
 end
 
 #load_balancer "#{instance_name}-elb" do


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Joshua Timberman

There seems to be a bug in machine_batch, possibly related to api
changes made in the aws-sdk-core gem upstream. For now we'll create
our omnitruck instances sequentially, since that's better than not
getting instances created at all.

Signed-off-by: Joshua Timberman <joshua@chef.io>



Ready to merge? View this change in Chef Automate and click the Approve button: https://delivery.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/85b576eb-00e2-4106-977e-2784e486f55a