### PR TITLE
Unmount the volumes just incase

### DIFF
--- a/.delivery/build-cookbook/recipes/default.rb
+++ b/.delivery/build-cookbook/recipes/default.rb
@@ -38,3 +38,13 @@ template File.join(node['delivery']['workspace']['root'], 'aws_config') do
 end
 
 include_recipe 'cia_infra::ruby'
+
+# Cleanup, just incase
+%w[
+  /hab/studios/omnitruck-build-publish
+  /hab/studios/omnitruck-build-publish/src
+].each do |u|
+  execute u do
+    returns [0,1]
+  end
+end

--- a/.delivery/build-cookbook/recipes/default.rb
+++ b/.delivery/build-cookbook/recipes/default.rb
@@ -43,8 +43,8 @@ include_recipe 'cia_infra::ruby'
 %w[
   /hab/studios/omnitruck-build-publish
   /hab/studios/omnitruck-build-publish/src
-].each do |u|
-  execute u do
+].each do |v|
+  execute "umount #{v}" do
     returns [0,1]
   end
 end


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Christopher Webber

We have consistently seen an issue where these volumes are not properly
unmounted from the last build. This will prevent that.

Signed-off-by: Christopher Webber <cwebber@chef.io>



Ready to merge? View this change in Chef Automate and click the Approve button: https://delivery.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/a588bede-7253-49b4-ba9f-2bbd445fa1ae