### PR TITLE
update hab_service to latest habitat cookbook

### DIFF
--- a/cookbooks/omnitruck/.kitchen.yml
+++ b/cookbooks/omnitruck/.kitchen.yml
@@ -15,4 +15,4 @@ suites:
       - recipe[omnitruck::default]
     attributes:
       applications:
-        omnitruck: 2015-09-19_1623
+        omnitruck: 873/20170420131452

--- a/cookbooks/omnitruck/metadata.rb
+++ b/cookbooks/omnitruck/metadata.rb
@@ -4,11 +4,11 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache2'
 description 'Installs/Configures omnitruck'
 long_description 'Installs/Configures omnitruck'
-version '0.3.14'
+version '0.4.0'
 
 depends 'delivery-sugar'
 depends 'cia_infra'
-depends 'habitat'
+depends 'habitat', '~> 0.4.0'
 
 issues_url 'https://github.com/chef/omnitruck/issues'
 source_url 'https://github.com/chef/omnitruck'

--- a/cookbooks/omnitruck/recipes/default.rb
+++ b/cookbooks/omnitruck/recipes/default.rb
@@ -22,44 +22,10 @@ hab_package 'chef-es/omnitruck-unicorn-proxy' do
   version node['applications']['omnitruck-unicorn-proxy']
 end
 
-hab_service 'chef-es/omnitruck' do
-  unit_content(lazy {
-    {
-      Unit: {
-        Description: 'omnitruck',
-        After: 'network.target audit.service omnitruck.service'
-      },
-      Service: {
-        Environment: [
-          "SSL_CERT_FILE=#{hab('pkg', 'path', 'core/cacerts').stdout.chomp}/ssl/cert.pem",
-          "HOME=/hab"
-        ],
-        ExecStart: "/bin/hab start chef-es/omnitruck",
-        Restart: "on-failure"
-      }
-    }
-    }
-  )
-  action [:enable, :start]
-end
+hab_sup 'default'
 
-hab_service 'chef-es/omnitruck-unicorn-proxy' do
-  unit_content(lazy {
-    {
-      Unit: {
-        Description: 'Nginx proxy for Unicorn',
-        After: 'network.target audit.service omnitruck.service'
-      },
-      Service: {
-        Environment: "SSL_CERT_FILE=#{hab('pkg', 'path', 'core/cacerts').stdout.chomp}/ssl/cert.pem",
-        ExecStart: "/bin/hab start chef-es/omnitruck-unicorn-proxy --listen-gossip 0.0.0.0:9639 --listen-http 0.0.0.0:9632",
-        Restart: "on-failure"
-      }
-    }
-    }
-  )
-  action [:enable, :start]
-end
+hab_service 'chef-es/omnitruck'
+hab_service 'chef-es/omnitruck-unicorn-proxy'
 
 cookbook_file '/etc/cron.d/poller-cron' do
   mode '0755'


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Joshua Timberman

The hab_service no longer uses the systemd unit files but loads
managed services in a running supervisor that has been set up with
hab_sup.

Signed-off-by: Joshua Timberman <joshua@chef.io>



Ready to merge? View this change in Chef Automate and click the Approve button: https://delivery.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/e6387fca-b2e7-4cb9-9da9-561ce8544070