### PR TITLE
pin bundler and ruby versions, create the cache directory

### DIFF
--- a/habitat/omnitruck/plan.sh
+++ b/habitat/omnitruck/plan.sh
@@ -37,7 +37,7 @@ pkg_deps=(
   core/glibc
   core/coreutils
   # omnitruck needs a particular version of Ruby
-  core/ruby/2.3.1
+  core/ruby
 )
 
 pkg_svc_user="hab"

--- a/habitat/omnitruck/plan.sh
+++ b/habitat/omnitruck/plan.sh
@@ -18,7 +18,6 @@ pkg_name=omnitruck
 pkg_origin=chef-es
 pkg_version=undefined
 pkg_shasum=undefined
-pkg_source=nosuchfile.tar.gz
 pkg_upstream_url="https://github.com/chef/omnitruck"
 pkg_maintainer="Chef Engineering Services <eng-services@chef.io>"
 pkg_description="API to query available versions of Omnibus artifacts"
@@ -30,14 +29,15 @@ pkg_build_deps=(
   core/make
   core/git
 )
-
 pkg_deps=(
-  core/bundler
+
   core/cacerts
   core/glibc
   core/coreutils
-  # omnitruck needs a particular version of Ruby
-  core/ruby
+  # omnitruck needs a particular version of bundler and ruby, there
+  # are issues with json in ruby 2.4 that we need to resolve first.
+  core/bundler/1.13.7/20170104000124
+  core/ruby/2.3.1/20161214031900
 )
 
 pkg_svc_user="hab"
@@ -55,10 +55,12 @@ do_verify() {
   pkg_dirname="${pkg_name}-${pkg_version}"
   pkg_prefix="$HAB_PKG_PATH/${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}"
   pkg_artifact="$HAB_CACHE_ARTIFACT_PATH/${pkg_origin}-${pkg_name}-${pkg_version}-${pkg_release}-${pkg_target}.${_artifact_ext}"
+attach
 }
 
 do_prepare() {
   pushd $PLAN_CONTEXT/../.. > /dev/null
+  mkdir -pv "$HAB_CACHE_SRC_PATH/${pkg_name}-${pkg_version}"
   tar -cvf - --exclude=.[a-z]* --exclude=results --exclude=cookbooks --exclude=spec --exclude=habitat . | (cd $HAB_CACHE_SRC_PATH/${pkg_name}-${pkg_version} && tar -xf - .)
   popd > /dev/null
 }


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Joshua Timberman

Omnitruck needs ruby 2.3.1, newer versions have a problem with the
json library that we haven't ironed out. We also need to pin the
bundler version because it will pull in a newer ruby if we don't, and
then we get dependency conflicts.

We also need to create the cache directory with the version in the
prepare step, as the variable that the plan build script used has
changed in habitat 0.21.0.

Signed-off-by: Joshua Timberman <joshua@chef.io>



Ready to merge? View this change in Chef Automate and click the Approve button: https://delivery.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/0813c205-c276-4b23-85df-9c06a5d9b2c1