### PR TITLE
Add HOME to habitat hooks

### DIFF
--- a/cookbooks/omnitruck/metadata.rb
+++ b/cookbooks/omnitruck/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache2'
 description 'Installs/Configures omnitruck'
 long_description 'Installs/Configures omnitruck'
-version '0.4.0'
+version '0.4.1'
 
 depends 'delivery-sugar'
 depends 'cia_infra'

--- a/cookbooks/omnitruck/recipes/default.rb
+++ b/cookbooks/omnitruck/recipes/default.rb
@@ -8,6 +8,7 @@ group 'hab'
 user 'hab' do
   group 'hab'
   home '/hab'
+  system true
 end
 
 hab_install 'habitat' do

--- a/habitat/omnitruck/hooks/init
+++ b/habitat/omnitruck/hooks/init
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export HOME="/hab"
+
 echo "Removing previous version deployed at {{pkg.svc_static_path}}"
 rm -rf {{pkg.svc_static_path}}/* {{pkg.svc_static_path}}/.bundle
 

--- a/habitat/omnitruck/hooks/run
+++ b/habitat/omnitruck/hooks/run
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+export HOME="/hab"
 export GEM_HOME="{{pkg.svc_static_path}}/vendor/bundle/ruby/2.3.0"
 export GEM_PATH="$(hab pkg path core/ruby)/lib/ruby/gems/2.3.0:$(hab pkg path core/bundler):$GEM_HOME"
 export LD_LIBRARY_PATH="$(hab pkg path core/gcc-libs)/lib"


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Joshua Timberman

Ruby's libreadline needs the $HOME environment variable set.
Previously (via 1404578) this was done in the systemd unit file.
However, we should do this in the habitat hooks.

Further, we should create hab as a system user to avoid potential UID
conflicts.

Signed-off-by: Joshua Timberman <joshua@chef.io>



Ready to merge? View this change in Chef Automate and click the Approve button: https://delivery.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/c17d9149-7178-4772-9bcc-3a7fcccdb6c1