### PR TITLE
Fix poller cron job user and SSL cert file

### DIFF
--- a/cookbooks/omnitruck/files/poller-cron
+++ b/cookbooks/omnitruck/files/poller-cron
@@ -2,5 +2,6 @@ PATH=$(hab pkg path core/bundler)/bin:$(hab pkg path core/ruby)/bin:$(hab pkg pa
 GEM_HOME="/hab/svc/omnitruck/static/vendor/bundle/ruby/2.3.0"
 GEM_PATH="$(hab pkg path core/ruby)/lib/ruby/gems/2.3.0:$(hab pkg path core/bundler):$GEM_HOME"
 LD_LIBRARY_PATH="$(hab pkg path core/gcc-libs)/lib"
+SSL_CERT_FILE="$(hab pkg path core/cacerts)/ssl/cert.pem"
 
-*/5 * * * * omnitruck cd /hab/svc/omnitruck/static && $(hab pkg path core/bundler)/bin/bundle exec ./poller -e production > /dev/null 2>&1
+*/5 * * * * hab cd /hab/svc/omnitruck/static && $(hab pkg path core/bundler)/bin/bundle exec ./poller -e production > /dev/null 2>&1

--- a/cookbooks/omnitruck/metadata.rb
+++ b/cookbooks/omnitruck/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache2'
 description 'Installs/Configures omnitruck'
 long_description 'Installs/Configures omnitruck'
-version '0.4.1'
+version '0.4.2'
 
 depends 'delivery-sugar'
 depends 'cia_infra'


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Joshua Timberman

In order to verify the SSL certificate, we need to export the proper
environment variable in the cron job. We also need to run the cron job
as the hab user, which now owns the application, instead of the
omnitruck user which no longer gets created.

Signed-off-by: Joshua Timberman <joshua@chef.io>



Ready to merge? View this change in Chef Automate and click the Approve button: https://delivery.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/9ed33109-82de-4b88-9ebe-dcb07b6e23a1