### PR TITLE
move cron to a shell script

### DIFF
--- a/cookbooks/omnitruck/files/poller-cron
+++ b/cookbooks/omnitruck/files/poller-cron
@@ -1,7 +1,1 @@
-PATH=$(hab pkg path core/bundler)/bin:$(hab pkg path core/ruby)/bin:$(hab pkg path core/coreutils)/bin:/usr/local/bin:/usr/local/sbin/:/usr/bin:/usr/sbin/:/bin:/sbin
-GEM_HOME="/hab/svc/omnitruck/static/vendor/bundle/ruby/2.3.0"
-GEM_PATH="$(hab pkg path core/ruby)/lib/ruby/gems/2.3.0:$(hab pkg path core/bundler):$GEM_HOME"
-LD_LIBRARY_PATH="$(hab pkg path core/gcc-libs)/lib"
-SSL_CERT_FILE="$(hab pkg path core/cacerts)/ssl/cert.pem"
-
-*/5 * * * * hab cd /hab/svc/omnitruck/static && $(hab pkg path core/bundler)/bin/bundle exec ./poller -e production > /dev/null 2>&1
+*/5 * * * * hab /usr/local/bin/poller-cron.sh

--- a/cookbooks/omnitruck/files/poller-cron.sh
+++ b/cookbooks/omnitruck/files/poller-cron.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+PATH=$(hab pkg path core/bundler)/bin:$(hab pkg path core/ruby)/bin:$(hab pkg path core/coreutils)/bin:/usr/local/bin:/usr/local/sbin/:/usr/bin:/usr/sbin/:/bin:/sbin
+GEM_HOME="/hab/svc/omnitruck/static/vendor/bundle/ruby/2.3.0"
+GEM_PATH="$(hab pkg path core/ruby)/lib/ruby/gems/2.3.0:$(hab pkg path core/bundler):$GEM_HOME"
+LD_LIBRARY_PATH="$(hab pkg path core/gcc-libs)/lib"
+SSL_CERT_FILE="$(hab pkg path core/cacerts)/ssl/cert.pem"
+
+export PATH GEM_HOME GEM_PATH LD_LIBRARY_PATH SSL_CERT_FILE
+
+cd /hab/svc/omnitruck/static && $(hab pkg path core/bundler)/bin/bundle exec ./poller -e production > /dev/null 2>&1

--- a/cookbooks/omnitruck/metadata.rb
+++ b/cookbooks/omnitruck/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache2'
 description 'Installs/Configures omnitruck'
 long_description 'Installs/Configures omnitruck'
-version '0.4.2'
+version '0.4.3'
 
 depends 'delivery-sugar'
 depends 'cia_infra'

--- a/cookbooks/omnitruck/recipes/default.rb
+++ b/cookbooks/omnitruck/recipes/default.rb
@@ -28,6 +28,10 @@ hab_sup 'default'
 hab_service 'chef-es/omnitruck'
 hab_service 'chef-es/omnitruck-unicorn-proxy'
 
+cookbook_file '/usr/local/bin/poller-cron.sh' do
+  mode '0755'
+end
+
 cookbook_file '/etc/cron.d/poller-cron' do
   mode '0755'
 end


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Joshua Timberman

In order to make it easier to test and reason about how the poller
cron job runs, move the job to a shell script that gets executed.

Signed-off-by: Joshua Timberman <joshua@chef.io>



Ready to merge? View this change in Chef Automate and click the Approve button: https://delivery.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/5252e171-979f-4f58-bf35-dcff57df09ae