### PR TITLE
restart the hab services on package changes

### DIFF
--- a/cookbooks/omnitruck/metadata.rb
+++ b/cookbooks/omnitruck/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache2'
 description 'Installs/Configures omnitruck'
 long_description 'Installs/Configures omnitruck'
-version '0.4.3'
+version '0.4.4'
 
 depends 'delivery-sugar'
 depends 'cia_infra'

--- a/cookbooks/omnitruck/recipes/default.rb
+++ b/cookbooks/omnitruck/recipes/default.rb
@@ -25,8 +25,13 @@ end
 
 hab_sup 'default'
 
-hab_service 'chef-es/omnitruck'
-hab_service 'chef-es/omnitruck-unicorn-proxy'
+hab_service 'chef-es/omnitruck' do
+  subscribes :restart, 'hab_package[chef-es/omnitruck]'
+end
+
+hab_service 'chef-es/omnitruck-unicorn-proxy' do
+  subscribes :restart, 'hab_package[chef-es/omnitruck-unicorn-proxy]'
+end
 
 cookbook_file '/usr/local/bin/poller-cron.sh' do
   mode '0755'


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Joshua Timberman

We're not using an update strategy that causes the services to restart
if the packages are updated, so we'll handle that with the recipe.
This ensures that application changes get picked up right away.

Signed-off-by: Joshua Timberman <joshua@chef.io>



Ready to merge? View this change in Chef Automate and click the Approve button: https://delivery.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/045e5b70-1f91-4f6a-ad68-9ab4f56bb153