### PR TITLE
Fix sles -> rhel mapping so sles 11 gets the correct rhel 5 (not 6) packages

### DIFF
--- a/platforms.rb
+++ b/platforms.rb
@@ -100,7 +100,7 @@ platform "sles" do
     if opts[:architecture] == "s390x"
       opts[:version]
     else
-      opts[:version].to_f <= 10 ? "5" : "6"
+      opts[:version].to_f <= 11 ? "5" : "6"
     end
   end
 end

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -284,9 +284,9 @@ context 'Omnitruck' do
                 let(:project_version) { nil }
                 let(:expected_info) do
                   {
-                    url: 'https://packages.chef.io/stable/el/6/i686/chef-12.4.3-1.el6.i386.rpm',
-                    sha256: '221890739edadcf46501154c8cbdba771612140364ca4afa8290327c4703a1ee',
-                    sha1: 'a71d6c0039753ad207848ca385bd0432',
+                    url: 'https://packages.chef.io/stable/el/5/i686/chef-12.4.3-1.el5.i386.rpm',
+                    sha256: 'ecd2cc4aa3606d74f697304cb1b18f9d2e5799d0906b8962052069ddf848fbd3',
+                    sha1: '90d6fc91edff9d81d901ca9d71325347',
                     version: '12.4.3'
                   }
                 end


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Scott Hain

Signed-off-by: Scott Hain <shain@chef.io>



Ready to merge? View this change in Chef Automate and click the Approve button: https://delivery.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/eb2067f2-d77d-4bcd-9706-eae0f21c70a1