### PR TITLE
Explicitly set Chef Server config on resources

### DIFF
--- a/.delivery/build-cookbook/libraries/_helper.rb
+++ b/.delivery/build-cookbook/libraries/_helper.rb
@@ -4,6 +4,7 @@
 #
 # Copyright (C) Chef Software, Inc. 2015
 #
+include Chef::Mixin::DeepMerge
 
 Chef::Resource.send(:include, Chef::Mixin::ShellOut)
 
@@ -86,4 +87,13 @@ def sns_topic
   else
     'arn:aws:sns:us-west-2:109983887395:cia-notify'
   end
+end
+
+def machine_options(node, aws_region, instance_num)
+  deep_merge(
+    CIAInfra.machine_options(node, aws_region, instance_num),
+    convergence_options: {
+      chef_server: chef_server_details
+    }
+  )
 end

--- a/.delivery/build-cookbook/metadata.rb
+++ b/.delivery/build-cookbook/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'you@example.com'
 license          'all_rights'
 description      'Installs/Configures build-cookbook'
 long_description 'Installs/Configures build-cookbook'
-version          '0.1.0'
+version          '0.1.1'
 
 chef_version '>= 12.19'
 
@@ -20,5 +20,3 @@ depends 'fastly'
 depends 'fancy_execute'
 depends 'habitat-build'
 depends 'expeditor'
-
-gem 'aws-sdk', '~> 2'

--- a/.delivery/build-cookbook/recipes/default.rb
+++ b/.delivery/build-cookbook/recipes/default.rb
@@ -26,10 +26,8 @@ include_recipe 'habitat-build::default'
 
 include_recipe 'fastly::default'
 
-load_delivery_chef_config
-
 # We need aws creds so we get them here.
-aws_creds = encrypted_data_bag_item_for_environment('cia-creds', 'chef-cia')
+aws_creds = with_server_config { encrypted_data_bag_item_for_environment('cia-creds', 'chef-cia') }
 
 template File.join(node['delivery']['workspace']['root'], 'aws_config') do
   source 'aws_config.erb'

--- a/.delivery/build-cookbook/recipes/functional.rb
+++ b/.delivery/build-cookbook/recipes/functional.rb
@@ -1,7 +1,5 @@
 include_recipe 'chef-sugar::default'
 
-load_delivery_chef_config
-
 site_name = 'omnitruck'
 domain_name = 'chef.io'
 

--- a/.delivery/build-cookbook/recipes/smoke.rb
+++ b/.delivery/build-cookbook/recipes/smoke.rb
@@ -1,7 +1,5 @@
 include_recipe 'chef-sugar::default'
 
-load_delivery_chef_config
-
 site_name = 'omnitruck'
 domain_name = 'chef.io'
 


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Seth Chisamore

By explicityly setting the Chef Server config on the various Chef
Provisioning resources and using the localized `with_server_config` in
other instances, we can avoid accidentally polluting the Automate
Runner's node object. Without this change all CIA pipelines are wiping
our runners Chef attributes, environment, tags and run list and thus
making it impossible to manage the configuration of said runners.

This is very much a band-aid fix that copies over changes that were
introduced to the `cia_infra` cookbook in chef-cookbooks/cia_infra#96.
We are not worried about making this project use `cia_infra` (and its
associated `cia_infra_cluster` resource) as Chef Provisioning will be
completely replaced by the Eng-Services standard Terraform module (and
other Eng-Services pipeline idioms) in the near future.

Signed-off-by: Seth Chisamore <schisamo@chef.io>



Ready to merge? View this change in Chef Automate and click the Approve button: https://automate.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/189ce1fa-dce3-40ae-8466-2590a96b03d0