### PR TITLE
Rename machine_options helper to machine_opts

### DIFF
--- a/.delivery/build-cookbook/libraries/_helper.rb
+++ b/.delivery/build-cookbook/libraries/_helper.rb
@@ -89,9 +89,9 @@ def sns_topic
   end
 end
 
-def machine_options(node, aws_region, instance_num)
+def machine_opts(instance_num)
   deep_merge(
-    CIAInfra.machine_options(node, aws_region, instance_num),
+    CIAInfra.machine_options(node, 'us-west-2', instance_num),
     convergence_options: {
       chef_server: chef_server_details
     }

--- a/.delivery/build-cookbook/metadata.rb
+++ b/.delivery/build-cookbook/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'you@example.com'
 license          'all_rights'
 description      'Installs/Configures build-cookbook'
 long_description 'Installs/Configures build-cookbook'
-version          '0.1.2'
+version          '0.1.3'
 
 chef_version '>= 12.19'
 

--- a/.delivery/build-cookbook/recipes/deploy.rb
+++ b/.delivery/build-cookbook/recipes/deploy.rb
@@ -49,7 +49,7 @@ machine_batch do
       attribute 'delivery_org', node['delivery']['change']['organization']
       attribute 'project', node['delivery']['change']['project']
       tags node['delivery']['change']['organization'], node['delivery']['change']['project']
-      machine_options machine_options(node, 'us-west-2', i)
+      machine_options machine_opts(i)
       files '/etc/chef/encrypted_data_bag_secret' => '/etc/chef/encrypted_data_bag_secret'
       run_list ['recipe[apt::default]', 'recipe[cia_infra::base]', 'recipe[omnitruck::default]']
       converge true

--- a/.delivery/build-cookbook/recipes/provision.rb
+++ b/.delivery/build-cookbook/recipes/provision.rb
@@ -59,7 +59,7 @@ instances = []
     attribute 'delivery_org', node['delivery']['change']['organization']
     attribute 'project', node['delivery']['change']['project']
     tags node['delivery']['change']['organization'], node['delivery']['change']['project']
-    machine_options machine_options(node, 'us-west-2', i)
+    machine_options machine_opts(i)
     files '/etc/chef/encrypted_data_bag_secret' => '/etc/chef/encrypted_data_bag_secret'
     converge false
     action :setup


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Seth Chisamore

Chef can't differentiate between a helper or resource property named the
same thing.

Signed-off-by: Seth Chisamore <schisamo@chef.io>



Ready to merge? View this change in Chef Automate and click the Approve button: https://automate.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/735c6d47-6d41-45fe-a329-583acb56b77e