### PR TITLE
use cron resource to create poller job

### DIFF
--- a/cookbooks/omnitruck/files/poller-cron
+++ b/cookbooks/omnitruck/files/poller-cron
@@ -1,1 +1,0 @@
-*/5 * * * * hab /usr/local/bin/poller-cron.sh

--- a/cookbooks/omnitruck/metadata.rb
+++ b/cookbooks/omnitruck/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache2'
 description 'Installs/Configures omnitruck'
 long_description 'Installs/Configures omnitruck'
-version '0.4.3'
+version '0.4.4'
 
 depends 'delivery-sugar'
 depends 'cia_infra'

--- a/cookbooks/omnitruck/recipes/default.rb
+++ b/cookbooks/omnitruck/recipes/default.rb
@@ -32,6 +32,8 @@ cookbook_file '/usr/local/bin/poller-cron.sh' do
   mode '0755'
 end
 
-cookbook_file '/etc/cron.d/poller-cron' do
-  mode '0755'
+cron 'run_poller_cron_sh' do
+  minute '*/5'
+  user 'hab'
+  command '/usr/local/bin/poller-cron.sh'
 end


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Patrick Wright

Signed-off-by: Patrick Wright <patrick@chef.io>

Simply dropping the poller cron file was not creating the job. Using `cron` resource instead.

Ready to merge? View this change in Chef Automate and click the Approve button: https://automate.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/787092df-ad4e-44d6-8491-98c6654f897a