### PR TITLE
add separate run list for build-essential which CCRs before cia_infra cookbook is compiled

### DIFF
--- a/cookbooks/omnitruck/metadata.rb
+++ b/cookbooks/omnitruck/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache2'
 description 'Installs/Configures omnitruck'
 long_description 'Installs/Configures omnitruck'
-version '0.4.11'
+version '0.4.12'
 
 depends 'delivery-sugar'
 depends 'cia_infra'

--- a/cookbooks/omnitruck/recipes/default.rb
+++ b/cookbooks/omnitruck/recipes/default.rb
@@ -16,20 +16,12 @@ hab_install 'habitat' do
 end
 
 hab_package 'chef-es/omnitruck' do
-  version node['applications']['omnitruck']
+  version '0.1.0'
 end
 
-hab_package 'chef-es/omnitruck-poller' do
-  version node['applications']['omnitruck-poller']
-end
-
-hab_package 'chef-es/omnitruck-web' do
-  version node['applications']['omnitruck-web']
-end
-
-hab_package 'chef-es/omnitruck-web-proxy' do
-  version node['applications']['omnitruck-web-proxy']
-end
+hab_package 'chef-es/omnitruck-poller'
+hab_package 'chef-es/omnitruck-web'
+hab_package 'chef-es/omnitruck-web-proxy'
 
 hab_sup 'default'
 


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Patrick Wright

Signed-off-by: Patrick Wright <patrick@chef.io>

cia_infra cookbook installs gems defined in the omnitruck cookbook metadata. 
cia_infra installs chef-provisioning-aws which depends on json 1.8.6. That gem needs to be installed via make.

In order to converge build-essentials first is needs to run as a separate run list.

----
Ready to merge? [View this change](https://automate.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/dc55ea38-2447-49ac-9c6e-ccb7530f6038) in Chef Automate and click the Approve button.