### PR TITLE
Teardown Acceptance, Union, and Rehearsal.

### DIFF
--- a/.delivery/build-cookbook/recipes/deploy.rb
+++ b/.delivery/build-cookbook/recipes/deploy.rb
@@ -62,9 +62,9 @@ run_lists.each do |r_list|
       machine "#{instance_name}-0#{i}" do
         chef_server chef_server_details
         chef_environment delivery_environment
-        attribute 'delivery_org', node['delivery']['change']['organization']
-        attribute 'project', node['delivery']['change']['project']
-        tags node['delivery']['change']['organization'], node['delivery']['change']['project']
+        attribute 'delivery_org', workflow_change_organization
+        attribute 'project', workflow_change_project
+        tags "#{workflow_change_organization}", "#{workflow_change_project}"
         machine_options machine_opts(i)
         files '/etc/chef/encrypted_data_bag_secret' => '/etc/chef/encrypted_data_bag_secret'
         run_list r_list
@@ -84,9 +84,9 @@ machine_batch do
     machine "#{instance_name}-#{i}" do
       chef_server chef_server_details
       chef_environment delivery_environment
-      attribute 'delivery_org', node['delivery']['change']['organization']
-      attribute 'project', node['delivery']['change']['project']
-      tags node['delivery']['change']['organization'], node['delivery']['change']['project']
+      attribute 'delivery_org', workflow_change_organization
+      attribute 'project', workflow_change_project
+      tags "#{workflow_change_organization}", "#{workflow_change_project}"
       machine_options machine_opts(i)
       files '/etc/chef/encrypted_data_bag_secret' => '/etc/chef/encrypted_data_bag_secret'
       run_list ['recipe[apt::default]', 'recipe[cia_infra::base]', 'recipe[omnitruck::default]']

--- a/.delivery/build-cookbook/recipes/functional.rb
+++ b/.delivery/build-cookbook/recipes/functional.rb
@@ -3,7 +3,7 @@ include_recipe 'chef-sugar::default'
 site_name = 'omnitruck'
 domain_name = 'chef.io'
 
-if node['delivery']['change']['stage'] == 'delivered'
+if workflow_stage?('delivered')
   bucket_name = node['delivery']['change']['project'].gsub(/_/, '-')
   fqdn = "#{site_name}.#{domain_name}"
 else
@@ -33,7 +33,7 @@ ruby_block 'check some things we broke' do
 end
 
 # Teardown Acceptance, Union, and Reheasal Omnitruck instances.
-if node['delivery']['change']['stage'] == 'delivered'
+if workflow_stage?('delivered')
   %w(acceptance union rehearsal).each do |env|
     machine_batch do
       # Nodes with name scheme: "omnitruck-env-1"
@@ -41,9 +41,9 @@ if node['delivery']['change']['stage'] == 'delivered'
         machine "#{instance_name}-#{i}" do
           chef_server chef_server_details
           chef_environment env
-          attribute 'delivery_org', node['delivery']['change']['organization']
-          attribute 'project', node['delivery']['change']['project']
-          tags node['delivery']['change']['organization'], node['delivery']['change']['project']
+          attribute 'delivery_org', workflow_change_organization
+          attribute 'project', workflow_change_project
+          tags "#{workflow_change_organization}", "#{workflow_change_project}"
           machine_options machine_opts(i)
           converge false
           action :destroy
@@ -55,9 +55,9 @@ if node['delivery']['change']['stage'] == 'delivered'
         machine "#{instance_name}-0#{i}" do
           chef_server chef_server_details
           chef_environment env
-          attribute 'delivery_org', node['delivery']['change']['organization']
-          attribute 'project', node['delivery']['change']['project']
-          tags node['delivery']['change']['organization'], node['delivery']['change']['project']
+          attribute 'delivery_org', workflow_change_organization
+          attribute 'project', workflow_change_project
+          tags "#{workflow_change_organization}", "#{workflow_change_project}"
           machine_options machine_opts(i)
           converge false
           action :destroy

--- a/.delivery/build-cookbook/recipes/functional.rb
+++ b/.delivery/build-cookbook/recipes/functional.rb
@@ -31,3 +31,38 @@ ruby_block 'check some things we broke' do
     end
   end
 end
+
+# Teardown Acceptance, Union, and Reheasal Omnitruck instances.
+if node['delivery']['change']['stage'] == 'delivered'
+  %w(acceptance union rehearsal).each do |env|
+    machine_batch do
+      # Nodes with name scheme: "omnitruck-env-1"
+      1.upto(instance_quantity) do |i|
+        machine "#{instance_name}-#{i}" do
+          chef_server chef_server_details
+          chef_environment env
+          attribute 'delivery_org', node['delivery']['change']['organization']
+          attribute 'project', node['delivery']['change']['project']
+          tags node['delivery']['change']['organization'], node['delivery']['change']['project']
+          machine_options machine_opts(i)
+          converge false
+          action :destroy
+        end
+      end
+
+      # Nodes with name scheme: "omnitruck-env-01"
+      1.upto(instance_quantity) do |i|
+        machine "#{instance_name}-0#{i}" do
+          chef_server chef_server_details
+          chef_environment env
+          attribute 'delivery_org', node['delivery']['change']['organization']
+          attribute 'project', node['delivery']['change']['project']
+          tags node['delivery']['change']['organization'], node['delivery']['change']['project']
+          machine_options machine_opts(i)
+          converge false
+          action :destroy
+        end
+      end
+    end
+  end
+end

--- a/.delivery/build-cookbook/recipes/provision.rb
+++ b/.delivery/build-cookbook/recipes/provision.rb
@@ -58,9 +58,9 @@ instances = []
   machine "#{instance_name}-0#{i}" do
     chef_server chef_server_details
     chef_environment delivery_environment
-    attribute 'delivery_org', node['delivery']['change']['organization']
-    attribute 'project', node['delivery']['change']['project']
-    tags node['delivery']['change']['organization'], node['delivery']['change']['project']
+    attribute 'delivery_org', workflow_change_organization
+    attribute 'project', workflow_change_project
+    tags "#{workflow_change_organization}", "#{workflow_change_project}"
     machine_options machine_opts(i)
     files '/etc/chef/encrypted_data_bag_secret' => '/etc/chef/encrypted_data_bag_secret'
     converge false
@@ -78,9 +78,9 @@ end
   machine "#{instance_name}-#{i}" do
     chef_server chef_server_details
     chef_environment delivery_environment
-    attribute 'delivery_org', node['delivery']['change']['organization']
-    attribute 'project', node['delivery']['change']['project']
-    tags node['delivery']['change']['organization'], node['delivery']['change']['project']
+    attribute 'delivery_org', workflow_change_organization
+    attribute 'project', workflow_change_project
+    tags "#{workflow_change_organization}", "#{workflow_change_project}"
     machine_options machine_opts(i)
     files '/etc/chef/encrypted_data_bag_secret' => '/etc/chef/encrypted_data_bag_secret'
     converge false

--- a/cookbooks/omnitruck/metadata.rb
+++ b/cookbooks/omnitruck/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache2'
 description 'Installs/Configures omnitruck'
 long_description 'Installs/Configures omnitruck'
-version '0.4.12'
+version '0.4.13'
 
 depends 'delivery-sugar'
 depends 'cia_infra'

--- a/cookbooks/omnitruck/recipes/default.rb
+++ b/cookbooks/omnitruck/recipes/default.rb
@@ -15,10 +15,7 @@ hab_install 'habitat' do
   action :upgrade
 end
 
-hab_package 'chef-es/omnitruck' do
-  version '0.1.0'
-end
-
+hab_package 'chef-es/omnitruck'
 hab_package 'chef-es/omnitruck-poller'
 hab_package 'chef-es/omnitruck-web'
 hab_package 'chef-es/omnitruck-web-proxy'

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -3,10 +3,17 @@
 #
 pkg_name=omnitruck
 pkg_origin=chef-es
-pkg_version="0.1.0"
+# Previous versions of omnitruck used an automatic version assignment for the
+# habitat pkg_version value which was base on the git commit count. Since we
+# use `sort --version-sort -r` in plan-build to determine the latest version of
+# any given package we need to set a value which sorts higher than the 950+
+# commits which are in the repo at the time of this change. Since we have 
+# additional hab services which depend on the omnitruck hab package, they will
+# uninintentionally install a version which is not the latest unless we use a
+# version which starts with 1000.x.x or greater.
+pkg_version=1000.0.0
 pkg_maintainer="Chef Engineering Services <eng-services@chef.io>"
 pkg_license=('Apache-2.0')
-
 # This is set to force the source path to the root level during automate builds
 # You must build plan from the root dir with command `build habitat`
 # Recommended to execute `scripts/hab-it`


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Ryan Hass

When omnitruck successfully provisions to Delivered, we need to
teardown the Acceptance, Union, and Rehearsal environments since they
are not really doing anything and add an unnessicary load on our backend.

Signed-off-by: Ryan Hass <rhass@users.noreply.github.com>



----
Ready to merge? [View this change](https://automate.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/ac11dec5-8c9e-4382-9bf1-1bcfc8d713ff) in Chef Automate and click the Approve button.