### PR TITLE
Rename omnitruck hab package to omnitruck-app

### DIFF
--- a/.delivery/build-cookbook/recipes/publish.rb
+++ b/.delivery/build-cookbook/recipes/publish.rb
@@ -22,7 +22,7 @@ if habitat_origin_key?
 end
 
 packages = {
-  "omnitruck" => "#{habitat_plan_dir}",
+  "omnitruck-app" => "#{habitat_plan_dir}",
   "omnitruck-poller" => "#{habitat_plan_dir}/omnitruck-poller",
   "omnitruck-web" => "#{habitat_plan_dir}/omnitruck-web",
   "omnitruck-web-proxy" => "#{habitat_plan_dir}/omnitruck-web-proxy",

--- a/cookbooks/omnitruck/metadata.rb
+++ b/cookbooks/omnitruck/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache2'
 description 'Installs/Configures omnitruck'
 long_description 'Installs/Configures omnitruck'
-version '0.4.13'
+version '0.4.14'
 
 depends 'delivery-sugar'
 depends 'cia_infra'

--- a/cookbooks/omnitruck/recipes/default.rb
+++ b/cookbooks/omnitruck/recipes/default.rb
@@ -15,14 +15,14 @@ hab_install 'habitat' do
   action :upgrade
 end
 
-hab_package 'chef-es/omnitruck'
+hab_package 'chef-es/omnitruck-app'
 hab_package 'chef-es/omnitruck-poller'
 hab_package 'chef-es/omnitruck-web'
 hab_package 'chef-es/omnitruck-web-proxy'
 
 hab_sup 'default'
 
-hab_service 'chef-es/omnitruck'
+hab_service 'chef-es/omnitruck-app'
 hab_service 'chef-es/omnitruck-poller'
 hab_service 'chef-es/omnitruck-web'
 hab_service 'chef-es/omnitruck-web-proxy'

--- a/habitat/README.md
+++ b/habitat/README.md
@@ -1,25 +1,34 @@
-omnitruck
+# omnitruck-app
 - ruby scaffolding
 - shared config
 - shared env vars
 
-omnitruck-poller
-- depends on omnitruck
+Install core Omnitruck Sinatra application and shared files
+
+# omnitruck-poller
+- depends on omnitruck-app for shared code and configuration
 - runs poller service
 
-omnitruck-web
-- depends on omnitruck
+Polls packages.chef.io periodically to scrape package properties to generate
+package metadata json files used to respond to queries.
+
+# omnitruck-web
+- depends on omnitruck-app
 - runs unicorn service
 
-omnitruck-web-proxy
+Provides Unicorn HTTP server and exposes a Unix and TCP socket.
+
+# omnitruck-web-proxy
+- depends on omnitruck-web
 - unicorn nginx config
-- used by omnitruck-web service
 
-build 'em all; start 'em all
+Provides Nginx proxy for connection routing and caching, and connects to the
+omntruck-web unix socket.
 
-They'll work it out
+## Testing
 
 Local testing:
 - enter studio
-- run `/habitat/go.sh`
-- `hab pkg exec core/curl curl 0.0.0.0:80/stable/automate/versions` (and the like)
+- Execute `scripts/hab-it`
+- `hab pkg exec core/curl curl "http://0.0.0.0/stable/automate/versions"`
+- `hab pkg exec core/curl curl "http://0.0.0.0/_status"`

--- a/habitat/config/config.yml
+++ b/habitat/config/config.yml
@@ -1,3 +1,3 @@
 {{cfg.omnitruck.rack_env}}:
   virtual_path: '{{cfg.omnitruck.virtual_path}}'
-  metadata_dir: '{{cfg.omnitruck.metadata_dir}}'
+  metadata_dir: '{{pkg.svc_var_path}}{{cfg.omnitruck.metadata_dir}}'

--- a/habitat/config/dotenv
+++ b/habitat/config/dotenv
@@ -1,4 +1,4 @@
 export HOME="{{pkg.svc_data_path}}"
 export OMNITRUCK_HOME="{{pkg.path}}/app"
 export OMNITRUCK_YAML="{{pkg.svc_config_path}}/config.yml"
-export SSL_CERT_FILE="$(hab pkg path core/cacerts)/ssl/cert.pem"
+export SSL_CERT_FILE="{{pkgPathFor "core/cacerts"}}/ssl/cert.pem"

--- a/habitat/default.toml
+++ b/habitat/default.toml
@@ -1,3 +1,3 @@
 [omnitruck]
 virtual_path = ""
-metadata_dir = "/hab/svc/omnitruck/var/poller_data"
+metadata_dir = "/poller_data"

--- a/habitat/omnitruck-poller/hooks/run
+++ b/habitat/omnitruck-poller/hooks/run
@@ -2,7 +2,7 @@
 #
 exec 2>&1
 
-. /hab/svc/omnitruck/config/dotenv
+. /hab/svc/omnitruck-app/config/dotenv
 
 cd $OMNITRUCK_HOME
 

--- a/habitat/omnitruck-poller/plan.sh
+++ b/habitat/omnitruck-poller/plan.sh
@@ -5,7 +5,7 @@ pkg_maintainer="Chef Engineering Services <eng-services@chef.io>"
 pkg_license=('Apache-2.0')
 
 pkg_deps=(
-  $HAB_ORIGIN/omnitruck
+  $HAB_ORIGIN/omnitruck-app
   core/coreutils
 )
 
@@ -14,5 +14,5 @@ do_build() {
 }
 
 do_install() {
-  fix_interpreter "$(pkg_path_for $HAB_ORIGIN/omnitruck)/app/poller" core/coreutils bin/env
+  fix_interpreter "$(pkg_path_for $HAB_ORIGIN/omnitruck-app)/app/poller" core/coreutils bin/env
 }

--- a/habitat/omnitruck-web-proxy/default.toml
+++ b/habitat/omnitruck-web-proxy/default.toml
@@ -1,6 +1,6 @@
 worker_rlimit_nofile = 8192
 worker_processes = "auto"
-upstream_server = "unix:/hab/svc/omnitruck/var/unicorn.sock.0"
+upstream_server = "unix:/hab/svc/omnitruck-app/var/unicorn.sock.0"
 
 [http]
 sendfile = "on"

--- a/habitat/omnitruck-web-proxy/plan.sh
+++ b/habitat/omnitruck-web-proxy/plan.sh
@@ -21,7 +21,11 @@ pkg_maintainer="Chef Engineering Services <eng-services@chef.io>"
 pkg_description="Nginx HTTP Proxy for Omnitruck"
 pkg_license=('Apache-2.0')
 
-pkg_deps=(core/nginx core/curl)
+pkg_deps=(
+  core/nginx
+  core/curl
+  $HAB_ORIGIN/omnitruck-web
+)
 pkg_svc_run="nginx -c ${pkg_svc_config_path}/nginx.conf"
 pkg_svc_user="root"
 pkg_svc_group=$pkg_svc_user

--- a/habitat/omnitruck-web/default.toml
+++ b/habitat/omnitruck-web/default.toml
@@ -1,5 +1,5 @@
 [unicorn]
-listen = "/hab/svc/omnitruck/var/unicorn.sock.0"
+listen = "/hab/svc/omnitruck-app/var/unicorn.sock.0"
 timeout = 60
 preload_app = false
 worker_processes = 8

--- a/habitat/omnitruck-web/hooks/init
+++ b/habitat/omnitruck-web/hooks/init
@@ -1,3 +1,3 @@
 #!/bin/sh
 #
-cp {{pkg.svc_config_path}}/unicorn.rb /hab/svc/omnitruck/config/
+cp {{pkg.svc_config_path}}/unicorn.rb /hab/svc/omnitruck-app/config/

--- a/habitat/omnitruck-web/hooks/run
+++ b/habitat/omnitruck-web/hooks/run
@@ -2,8 +2,8 @@
 #
 exec 2>&1
 
-. /hab/svc/omnitruck/config/dotenv
+. /hab/svc/omnitruck-app/config/dotenv
 
 cd $OMNITRUCK_HOME
 
-exec bundle exec unicorn -E production -c /hab/svc/omnitruck/config/unicorn.rb config.ru
+exec bundle exec unicorn -E production -c /hab/svc/omnitruck-app/config/unicorn.rb config.ru

--- a/habitat/omnitruck-web/plan.sh
+++ b/habitat/omnitruck-web/plan.sh
@@ -5,7 +5,7 @@ pkg_maintainer="Chef Engineering Services <eng-services@chef.io>"
 pkg_license=('Apache-2.0')
 
 pkg_deps=(
-  $HAB_ORIGIN/omnitruck
+  $HAB_ORIGIN/omnitruck-app
 )
 
 do_build() {

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,17 +1,9 @@
 # omnitruck plan is located in /habitat root because of ruby scaffolding.
 # Scaffolding looks for a relative Gemfile
 #
-pkg_name=omnitruck
+pkg_name=omnitruck-app
 pkg_origin=chef-es
-# Previous versions of omnitruck used an automatic version assignment for the
-# habitat pkg_version value which was base on the git commit count. Since we
-# use `sort --version-sort -r` in plan-build to determine the latest version of
-# any given package we need to set a value which sorts higher than the 950+
-# commits which are in the repo at the time of this change. Since we have 
-# additional hab services which depend on the omnitruck hab package, they will
-# uninintentionally install a version which is not the latest unless we use a
-# version which starts with 1000.x.x or greater.
-pkg_version=1000.0.0
+pkg_version=0.1.0
 pkg_maintainer="Chef Engineering Services <eng-services@chef.io>"
 pkg_license=('Apache-2.0')
 # This is set to force the source path to the root level during automate builds

--- a/scripts/hab-it
+++ b/scripts/hab-it
@@ -4,7 +4,7 @@ build habitat && \
 build habitat/omnitruck-poller && \
 build habitat/omnitruck-web && \
 build habitat/omnitruck-web-proxy && \
-hab start $HAB_ORIGIN/omnitruck && \
+hab start $HAB_ORIGIN/omnitruck-app && \
 hab start $HAB_ORIGIN/omnitruck-poller && \
 hab start $HAB_ORIGIN/omnitruck-web && \
 hab start $HAB_ORIGIN/omnitruck-web-proxy


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Ryan Hass

We are renaming the application to ensure we have a clean versioning
space to prevent issues with building new nodes.

Signed-off-by: Ryan Hass <rhass@users.noreply.github.com>



----
Ready to merge? [View this change](https://automate.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/5062c791-d159-407f-b515-4a27cff7049b) in Chef Automate and click the Approve button.