### PR TITLE
Run apt cookbook first.

### DIFF
--- a/.delivery/build-cookbook/recipes/deploy.rb
+++ b/.delivery/build-cookbook/recipes/deploy.rb
@@ -50,8 +50,8 @@ fqdn = "#{instance_name}.#{domain_name}"
 # In short, this gets around the issue where build-essential was installed
 # manually on omnitruck instances for all environments.
 run_lists = [
-  ['recipe[build-essential::default]'],
-  ['recipe[apt::default]', 'recipe[cia_infra::base]', 'recipe[omnitruck::default]'],
+  ['recipe[apt::default]', 'recipe[build-essential::default]'],
+  ['recipe[cia_infra::base]', 'recipe[omnitruck::default]'],
 ]
 
 # Instances using latest omnitruck habitat packages


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Ryan Hass

We need to run `apt-get update` before we try to install
build-essential.

Signed-off-by: Ryan Hass <rhass@users.noreply.github.com>



----
Ready to merge? [View this change](https://automate.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/6f770e6a-bdc3-479f-9d6f-5f49aa035199) in Chef Automate and click the Approve button.