### PR TITLE
stop hab services after delivered phase

### DIFF
--- a/.delivery/build-cookbook/libraries/_helper.rb
+++ b/.delivery/build-cookbook/libraries/_helper.rb
@@ -81,6 +81,10 @@ def delivered_stage?
   end
 end
 
+def union_or_rehearsal?
+  (workflow_stage?('union') || workflow_stage?('rehearsal'))
+end
+
 def sns_topic
   if delivered_stage?
     'arn:aws:sns:us-west-2:109983887395:cia-alert'

--- a/.delivery/build-cookbook/recipes/deploy.rb
+++ b/.delivery/build-cookbook/recipes/deploy.rb
@@ -1,3 +1,5 @@
+return if union_or_rehearsal?
+
 include_recipe 'chef-sugar::default'
 
 fastly_creds = with_server_config { encrypted_data_bag_item_for_environment('cia-creds','fastly') }

--- a/.delivery/build-cookbook/recipes/functional.rb
+++ b/.delivery/build-cookbook/recipes/functional.rb
@@ -60,7 +60,8 @@ if workflow_stage?('delivered')
           tags "#{workflow_change_organization}", "#{workflow_change_project}"
           machine_options machine_opts(i)
           converge false
-          action :destroy
+          run_list ['recipe[omnitruck::stop_services]']
+          action :converge
         end
       end
     end

--- a/.delivery/build-cookbook/recipes/functional.rb
+++ b/.delivery/build-cookbook/recipes/functional.rb
@@ -1,3 +1,5 @@
+return if union_or_rehearsal?
+
 include_recipe 'chef-sugar::default'
 
 site_name = 'omnitruck'

--- a/.delivery/build-cookbook/recipes/lint.rb
+++ b/.delivery/build-cookbook/recipes/lint.rb
@@ -4,6 +4,8 @@
 # This recipe is run as the delivery user
 ################################################################################
 
+return if union_or_rehearsal?
+
 # Run lint against the cookbooks
 include_recipe 'delivery-truck::lint'
 include_recipe 'habitat-build::lint'

--- a/.delivery/build-cookbook/recipes/provision.rb
+++ b/.delivery/build-cookbook/recipes/provision.rb
@@ -1,3 +1,5 @@
+return if union_or_rehearsal?
+
 include_recipe 'chef-sugar::default'
 include_recipe 'delivery-truck::provision'
 

--- a/.delivery/build-cookbook/recipes/publish.rb
+++ b/.delivery/build-cookbook/recipes/publish.rb
@@ -7,6 +7,8 @@
 #
 ################################################################################
 
+return if union_or_rehearsal?
+
 include_recipe 'chef-sugar::default'
 include_recipe 'delivery-truck::publish'
 

--- a/.delivery/build-cookbook/recipes/smoke.rb
+++ b/.delivery/build-cookbook/recipes/smoke.rb
@@ -1,3 +1,5 @@
+return if union_or_rehearsal?
+
 include_recipe 'chef-sugar::default'
 
 site_name = 'omnitruck'

--- a/.delivery/build-cookbook/recipes/syntax.rb
+++ b/.delivery/build-cookbook/recipes/syntax.rb
@@ -4,6 +4,8 @@
 # This recipe is executed as the delivery user
 ################################################################################
 
+return if union_or_rehearsal?
+
 # Check the syntax on the cookbooks in cookbooks/
 include_recipe 'delivery-truck::syntax'
 

--- a/.delivery/build-cookbook/recipes/unit.rb
+++ b/.delivery/build-cookbook/recipes/unit.rb
@@ -4,6 +4,8 @@
 # This phase is run as the delivery user
 ################################################################################
 
+return if union_or_rehearsal?
+
 secrets = get_project_secrets
 
 # This resource queries the Github API to determine "completeness" based on

--- a/.delivery/config.json
+++ b/.delivery/config.json
@@ -5,7 +5,8 @@
       "path": ".delivery/build-cookbook"
   },
   "skip_phases": [
-    "quality"
+    "quality",
+    "security"
   ],
   "job_dispatch": {
     "version": "v2",

--- a/cookbooks/omnitruck/metadata.rb
+++ b/cookbooks/omnitruck/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache2'
 description 'Installs/Configures omnitruck'
 long_description 'Installs/Configures omnitruck'
-version '0.4.14'
+version '0.4.15'
 
 depends 'delivery-sugar'
 depends 'cia_infra'

--- a/cookbooks/omnitruck/recipes/stop_services.rb
+++ b/cookbooks/omnitruck/recipes/stop_services.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook Name:: omnitruck
+# Recipe:: stop_services
+#
+
+hab_service 'chef-es/omnitruck-app' do
+  action :stop
+end
+
+hab_service 'chef-es/omnitruck-poller' do
+  action :stop
+end
+
+hab_service 'chef-es/omnitruck-web' do
+  action :stop
+end
+
+hab_service 'chef-es/omnitruck-web-proxy' do
+  action :stop
+end


### PR DESCRIPTION
We don't want to change ELB management from the existing pipeline. Rather than destroying the new instances we will stop the hab services.

This Pull Request was opened by Chef Automate user Patrick Wright

Signed-off-by: Patrick Wright <patrick@chef.io>



----
Ready to merge? [View this change](https://automate.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/dc060aae-b864-43b6-a124-0b7a70df58ed) in Chef Automate and click the Approve button.