### PR TITLE
Run fix interpreter from the app package.

### DIFF
--- a/habitat/omnitruck-poller/plan.sh
+++ b/habitat/omnitruck-poller/plan.sh
@@ -6,7 +6,6 @@ pkg_license=('Apache-2.0')
 
 pkg_deps=(
   $HAB_ORIGIN/omnitruck-app
-  core/coreutils
 )
 
 do_build() {
@@ -14,5 +13,5 @@ do_build() {
 }
 
 do_install() {
-  fix_interpreter "$(pkg_path_for $HAB_ORIGIN/omnitruck-app)/app/poller" core/coreutils bin/env
+  return 0
 }

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -6,6 +6,9 @@ pkg_origin=chef-es
 pkg_version=0.1.0
 pkg_maintainer="Chef Engineering Services <eng-services@chef.io>"
 pkg_license=('Apache-2.0')
+pkg_deps=(
+  core/coreutils
+)
 # This is set to force the source path to the root level during automate builds
 # You must build plan from the root dir with command `build habitat`
 # Recommended to execute `scripts/hab-it`
@@ -13,3 +16,8 @@ SRC_PATH="../"
 
 pkg_scaffolding=core/scaffolding-ruby
 scaffolding_ruby_pkg=core/ruby/$(cat "$PLAN_CONTEXT/../.ruby-version")
+
+do_install() {
+  do_default_install
+  fix_interpreter "$pkg_prefix/app/poller" core/coreutils bin/env
+}


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Ryan Hass

We were trying to run fix_interpreter from the wrong package which does
not work for installed packages since the change is not updated in the
hart file itself and only works in the build phases.

Signed-off-by: Ryan Hass <rhass@users.noreply.github.com>
Signed-off-by: Patrick Wright <patrick@chef.io>



----
Ready to merge? [View this change](https://automate.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/b64f31b6-a94f-4d55-a1ac-0585f47f1845) in Chef Automate and click the Approve button.