### PR TITLE
Use generated node attributes for package version.

### DIFF
--- a/cookbooks/omnitruck/metadata.rb
+++ b/cookbooks/omnitruck/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache2'
 description 'Installs/Configures omnitruck'
 long_description 'Installs/Configures omnitruck'
-version '0.4.15'
+version '0.4.16'
 
 depends 'delivery-sugar'
 depends 'cia_infra'

--- a/cookbooks/omnitruck/recipes/default.rb
+++ b/cookbooks/omnitruck/recipes/default.rb
@@ -15,14 +15,16 @@ hab_install 'habitat' do
   action :upgrade
 end
 
-hab_package 'chef-es/omnitruck-app'
-hab_package 'chef-es/omnitruck-poller'
-hab_package 'chef-es/omnitruck-web'
-hab_package 'chef-es/omnitruck-web-proxy'
+packages = %w(omnitruck-app omnitruck-poller omnitruck-web omnitruck-web-proxy)
+
+packages.each do |pkg|
+  hab_package "chef-es/#{pkg}" do
+    version node['applications'][pkg]
+  end
+end
 
 hab_sup 'default'
 
-hab_service 'chef-es/omnitruck-app'
-hab_service 'chef-es/omnitruck-poller'
-hab_service 'chef-es/omnitruck-web'
-hab_service 'chef-es/omnitruck-web-proxy'
+packages.each do |pkg|
+  hab_service "chef-es/#{pkg}"
+end


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Ryan Hass

The habitat cookbook automatically generates a node attribute which
must be passed through to the hab_package resource for the latest
version value to be respected.

Signed-off-by: Ryan Hass <rhass@users.noreply.github.com>



----
Ready to merge? [View this change](https://automate.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/67681c54-17e0-4fb9-9245-67ab21b672e2) in Chef Automate and click the Approve button.