### PR TITLE
reload hab services after package install

### DIFF
--- a/cookbooks/omnitruck/metadata.rb
+++ b/cookbooks/omnitruck/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache2'
 description 'Installs/Configures omnitruck'
 long_description 'Installs/Configures omnitruck'
-version '0.4.16'
+version '0.4.17'
 
 depends 'delivery-sugar'
 depends 'cia_infra'

--- a/cookbooks/omnitruck/recipes/default.rb
+++ b/cookbooks/omnitruck/recipes/default.rb
@@ -20,6 +20,7 @@ packages = %w(omnitruck-app omnitruck-poller omnitruck-web omnitruck-web-proxy)
 packages.each do |pkg|
   hab_package "chef-es/#{pkg}" do
     version node['applications'][pkg]
+    notifies :unload, "hab_service[chef-es/#{pkg}]", :immediately
   end
 end
 


### PR DESCRIPTION
Latest hab packages do get installed, but the supervisor won't load the latest package unless the current running package service is unloaded first.

This Pull Request was opened by Chef Automate user Patrick Wright

Signed-off-by: Patrick Wright <patrick@chef.io>

----

Ready to merge? [View this change](https://automate.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/c8755347-08ad-491d-8bba-b26ac0799a0b) in Chef Automate and click the Approve button.