### PR TITLE
Start hab supervisor before any other actions.

### DIFF
--- a/cookbooks/omnitruck/metadata.rb
+++ b/cookbooks/omnitruck/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache2'
 description 'Installs/Configures omnitruck'
 long_description 'Installs/Configures omnitruck'
-version '0.4.17'
+version '0.4.18'
 
 depends 'delivery-sugar'
 depends 'cia_infra'

--- a/cookbooks/omnitruck/recipes/default.rb
+++ b/cookbooks/omnitruck/recipes/default.rb
@@ -17,14 +17,16 @@ end
 
 packages = %w(omnitruck-app omnitruck-poller omnitruck-web omnitruck-web-proxy)
 
+# The supervisor must be running before we can send an unload since the
+# resource will try to hit the supervisors http management endpoint.
+hab_sup 'default'
+
 packages.each do |pkg|
   hab_package "chef-es/#{pkg}" do
     version node['applications'][pkg]
     notifies :unload, "hab_service[chef-es/#{pkg}]", :immediately
   end
 end
-
-hab_sup 'default'
 
 packages.each do |pkg|
   hab_service "chef-es/#{pkg}"


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Ryan Hass

We need to ensure the supervisor is running before attempting to unload
or load any hab packages to ensure the hab HTTP management endpoint is
available.

Signed-off-by: Ryan Hass <rhass@users.noreply.github.com>



----
Ready to merge? [View this change](https://automate.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/699f1833-9b45-4e10-87b4-8b62133fb433) in Chef Automate and click the Approve button.