### PR TITLE
Pull in and configure provisioning-aws for teardown

### DIFF
--- a/.delivery/build-cookbook/recipes/functional.rb
+++ b/.delivery/build-cookbook/recipes/functional.rb
@@ -33,6 +33,14 @@ ruby_block 'check some things we broke' do
 end
 
 # Teardown Acceptance, Union, and Reheasal Omnitruck instances.
+require 'chef/provisioning/aws_driver'
+ENV['AWS_CONFIG_FILE'] = File.join(node['delivery']['workspace']['root'], 'aws_config')
+
+with_driver 'aws::us-west-2'
+
+with_chef_server chef_server_details[:chef_server_url],
+                 chef_server_details[:options]
+
 if workflow_stage?('delivered')
   %w(acceptance union rehearsal).each do |env|
     instance_name = "omnitruck-#{env}"


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Ryan Hass

Add missing some required bits to be able to execute the teardown
against aws correctly.

Signed-off-by: Ryan Hass <rhass@users.noreply.github.com>



----
Ready to merge? [View this change](https://automate.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/c5388e66-fab9-40b7-9528-76e4d4a51131) in Chef Automate and click the Approve button.