### PR TITLE
skip union, rehearsal

### DIFF
--- a/.delivery/build-cookbook/recipes/deploy.rb
+++ b/.delivery/build-cookbook/recipes/deploy.rb
@@ -1,3 +1,5 @@
+return if (workflow_stage?('union') || workflow_stage?('rehearsal'))
+
 include_recipe 'chef-sugar::default'
 
 fastly_creds = with_server_config { encrypted_data_bag_item_for_environment('cia-creds','fastly') }

--- a/.delivery/build-cookbook/recipes/functional.rb
+++ b/.delivery/build-cookbook/recipes/functional.rb
@@ -1,3 +1,5 @@
+return if (workflow_stage?('union') || workflow_stage?('rehearsal'))
+
 include_recipe 'chef-sugar::default'
 
 site_name = 'omnitruck'

--- a/.delivery/build-cookbook/recipes/provision.rb
+++ b/.delivery/build-cookbook/recipes/provision.rb
@@ -1,6 +1,9 @@
 include_recipe 'chef-sugar::default'
 include_recipe 'delivery-truck::provision'
 
+# Return after 'delivery-truck::provision' recipe converges
+return if (workflow_stage?('union') || workflow_stage?('rehearsal'))
+
 aws_creds = with_server_config { encrypted_data_bag_item_for_environment('cia-creds','chef-secure') }
 fastly_creds = with_server_config { encrypted_data_bag_item_for_environment('cia-creds','fastly') }
 

--- a/.delivery/build-cookbook/recipes/smoke.rb
+++ b/.delivery/build-cookbook/recipes/smoke.rb
@@ -1,3 +1,5 @@
+return if (workflow_stage?('union') || workflow_stage?('rehearsal'))
+
 include_recipe 'chef-sugar::default'
 
 site_name = 'omnitruck'


### PR DESCRIPTION
Speed up workflow pipeline. Union and rehearsal are not much use to omnitruck.

This time delivery-truck::provision is called which should set up the chef-server as we'd expect.

This Pull Request was opened by Chef Automate user Patrick Wright

Signed-off-by: Patrick Wright <patrick@chef.io>



----
Ready to merge? [View this change](https://automate.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/383efbe8-e501-4fb1-82f6-2691000c9228) in Chef Automate and click the Approve button.