### PR TITLE
Send restart to supervisor on upgrade.

### DIFF
--- a/cookbooks/omnitruck/metadata.rb
+++ b/cookbooks/omnitruck/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache2'
 description 'Installs/Configures omnitruck'
 long_description 'Installs/Configures omnitruck'
-version '0.4.18'
+version '0.4.19'
 
 depends 'delivery-sugar'
 depends 'cia_infra'

--- a/cookbooks/omnitruck/recipes/default.rb
+++ b/cookbooks/omnitruck/recipes/default.rb
@@ -29,5 +29,7 @@ packages.each do |pkg|
 end
 
 packages.each do |pkg|
-  hab_service "chef-es/#{pkg}"
+  hab_service "chef-es/#{pkg}" do
+    notifies :restart, "service[hab-sup-default]", :delayed
+  end
 end


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Ryan Hass

We need to send a restart to the supervisor rather than use Habitat
update strategy since we do not currently leverage Habitat channels.
This is needed so we can control updates to different environments
since the hab supervisor does not restart services automatically when a
new version is installed without an update strategy defined.

Signed-off-by: Ryan Hass <rhass@users.noreply.github.com>



----
Ready to merge? [View this change](https://automate.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/5abc40ee-652c-4632-9e70-f1f06262008e) in Chef Automate and click the Approve button.