### PR TITLE
machine_batch stop

### DIFF
--- a/.delivery/build-cookbook/recipes/functional.rb
+++ b/.delivery/build-cookbook/recipes/functional.rb
@@ -46,6 +46,8 @@ with_chef_server chef_server_details[:chef_server_url],
 # Once delivered to production we stop acceptance instances
 if workflow_stage?('delivered')
   machine_batch do
+    action :stop
+
     1.upto(instance_quantity) do |i|
       machine "omnitruck-acceptance-0#{i}" do
         chef_server chef_server_details


### PR DESCRIPTION
machine action is ignored. Need to set action for machine_batch

This Pull Request was opened by Chef Automate user Patrick Wright

Signed-off-by: Patrick Wright <patrick@chef.io>



----
Ready to merge? [View this change](https://automate.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/48899bc2-8e6f-4c29-bb53-ac1b4db91f21) in Chef Automate and click the Approve button.