### PR TITLE
Add application name to user-agent header.

### DIFF
--- a/lib/chef/project_manifest.rb
+++ b/lib/chef/project_manifest.rb
@@ -137,7 +137,8 @@ class Chef
     def available_versions
       Mixlib::Install.new(
         product_name: project_name,
-        channel: channel_name.to_sym
+        channel: channel_name.to_sym,
+        user_agent_headers: ['omnitruck']
       ).available_versions
     rescue Mixlib::Install::Backend::ArtifactsNotFound
       # Return an empty array if no artifacts are found
@@ -155,7 +156,8 @@ class Chef
       artifacts = Mixlib::Install.new(
         product_name: project_name,
         channel: channel_name.to_sym,
-        product_version: version
+        product_version: version,
+        user_agent_headers: ['omnitruck']
       ).artifact_info
 
       Array(artifacts)


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Ryan Hass

The addition of the application name to the user-agent header helps us
better identify and analyize traffic and usage patterns with the
package-router.



----
Ready to merge? [View this change](https://automate.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/a8023015-77de-4a69-aa99-d2c4654141d0) in Chef Automate and click the Approve button.