### PR TITLE
Update to hab-it for omnitruck-app build

### DIFF
--- a/scripts/hab-it
+++ b/scripts/hab-it
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-build habitat && \
+build && \
 build habitat/omnitruck-poller && \
 build habitat/omnitruck-web && \
 build habitat/omnitruck-web-proxy && \


### PR DESCRIPTION
Addressing error in https://github.com/chef/omnitruck/issues/322

Update to hab-it to use build for omnitruck-app, not build/habitat