### PR TITLE
Update CNAME for Fastly.

### DIFF
--- a/.delivery/build-cookbook/recipes/provision.rb
+++ b/.delivery/build-cookbook/recipes/provision.rb
@@ -239,7 +239,7 @@ end
 
 route53_record fqdn do
   name "#{fqdn}."
-  value 'g.global-ssl.fastly.net'
+  value 'f4.shared.global.fastly.net'
   aws_access_key_id aws_creds['access_key_id']
   aws_secret_access_key aws_creds['secret_access_key']
   type 'CNAME'


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Ryan Hass

This updates the CNAME to use the Fastly legacy CDN host which supports
SSLv3, TLS 1.0, and TLS 1.1 which will be supported until June 2018.

Signed-off-by: Ryan Hass <rhass@users.noreply.github.com>



----
Ready to merge? [View this change](https://automate.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/2e28827e-cf5d-4910-9be6-33a497105571) in Chef Automate and click the Approve button.