### PR TITLE
update mixlib-install 3.9.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GEM
     kgio (2.10.0)
     method_source (0.8.2)
     mime-types (1.25.1)
-    mixlib-install (3.8.0)
+    mixlib-install (3.9.0)
       mixlib-shellout
       mixlib-versioning
       thor


### PR DESCRIPTION
mixlib-install 3.9.0 adds amazon linux 2.0 detection support.

This Pull Request was opened by Chef Automate user Patrick Wright

Signed-off-by: Patrick Wright <patrick@chef.io>



----
Ready to merge? [View this change](https://automate.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/25b695e6-bd60-4edf-8f55-080f500a7022) in Chef Automate and click the Approve button.