### PR TITLE
Update CORS configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'sinatra', '~> 1.4', '< 2'
 gem 'sinatra-contrib'
-gem 'sinatra-cross_origin'
+gem 'sinatra-cors'
 gem 'unicorn'
 gem 'json'
 gem 'colorize'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
       rack-test
       sinatra (~> 1.4.0)
       tilt (>= 1.3, < 3)
-    sinatra-cross_origin (0.4.0)
+    sinatra-cors (1.1.0)
     slop (3.6.0)
     statsd-ruby (1.2.1)
     thor (0.20.0)
@@ -116,7 +116,7 @@ DEPENDENCIES
   rspec_junit_formatter
   sinatra (~> 1.4, < 2)
   sinatra-contrib
-  sinatra-cross_origin
+  sinatra-cors
   trashed
   unicorn
   yajl-ruby

--- a/app.rb
+++ b/app.rb
@@ -21,7 +21,7 @@
 
 require 'sinatra'
 require 'sinatra/config_file'
-require 'sinatra/cross_origin'
+require "sinatra/cors"
 require 'json'
 require 'pp'
 
@@ -40,17 +40,21 @@ require 'chef/version_resolver'
 
 class Omnitruck < Sinatra::Base
   register Sinatra::ConfigFile
-  register Sinatra::CrossOrigin
+  register Sinatra::Cors
 
   config_file ENV['OMNITRUCK_YAML'] || './config/config.yml'
 
   class InvalidChannelName < StandardError; end
 
   configure do
-    set :allow_origin, :any
+    # CORS support
+    set :allow_origin, "*"
+    set :allow_methods, "GET"
+    set :allow_headers, "content-type,if-modified-since"
+
     set :raise_errors, false
     set :show_exceptions, false
-    enable :cross_origin
+
     enable :logging
 
     set :logging, nil

--- a/habitat/omnitruck-poller/Gemfile
+++ b/habitat/omnitruck-poller/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'sinatra', '~> 1.4', '< 2'
 gem 'sinatra-contrib'
-gem 'sinatra-cross_origin'
+gem 'sinatra-cors'
 gem 'unicorn'
 gem 'json'
 gem 'colorize'

--- a/habitat/omnitruck-poller/Gemfile.lock
+++ b/habitat/omnitruck-poller/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
       rack-test
       sinatra (~> 1.4.0)
       tilt (>= 1.3, < 3)
-    sinatra-cross_origin (0.4.0)
+    sinatra-cors (1.1.0)
     slop (3.6.0)
     statsd-ruby (1.2.1)
     thor (0.20.0)
@@ -116,7 +116,7 @@ DEPENDENCIES
   rspec_junit_formatter
   sinatra (~> 1.4, < 2)
   sinatra-contrib
-  sinatra-cross_origin
+  sinatra-cors
   trashed
   unicorn
   yajl-ruby

--- a/habitat/omnitruck-web/Gemfile
+++ b/habitat/omnitruck-web/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'sinatra', '~> 1.4', '< 2'
 gem 'sinatra-contrib'
-gem 'sinatra-cross_origin'
+gem 'sinatra-cors'
 gem 'unicorn'
 gem 'json'
 gem 'colorize'

--- a/habitat/omnitruck-web/Gemfile.lock
+++ b/habitat/omnitruck-web/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
       rack-test
       sinatra (~> 1.4.0)
       tilt (>= 1.3, < 3)
-    sinatra-cross_origin (0.4.0)
+    sinatra-cors (1.1.0)
     slop (3.6.0)
     statsd-ruby (1.2.1)
     thor (0.20.0)
@@ -116,7 +116,7 @@ DEPENDENCIES
   rspec_junit_formatter
   sinatra (~> 1.4, < 2)
   sinatra-contrib
-  sinatra-cross_origin
+  sinatra-cors
   trashed
   unicorn
   yajl-ruby


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Seth Chisamore

Switch to the more full-features `sinatra-cors` gem. I've also validated
the expected `Access-Control-Allow-Origin` header is returned when a
`Origin` header is provided in the request:

```
➜  curl -i -H "Origin: foo" -H "Accept: application/json" "http://localhost:8080/current/chef/metadata?p=mac_os_x&pv=10.13&m=x86_64"
HTTP/1.1 200 OK
Date: Fri, 11 May 2018 01:39:59 GMT
Connection: close
Content-Type: text/html;charset=utf-8
Access-Control-Allow-Origin: foo
Content-Length: 255
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN

{
  "sha1": "061ecc2ff3462ccfc23f3b5e4e4b51107d64d8bf",
  "sha256": "b02a844ef54d1b113b31c26184548360a8d8da86b9c0b5a03bd2bcb52b8745d8",
  "url": "https://packages.chef.io/files/current/chef/14.1.1/mac_os_x/10.13/chef-14.1.1-1.dmg",
  "version": "14.1.1"
}
```

Signed-off-by: Seth Chisamore <schisamo@chef.io>



----
Ready to merge? [View this change](https://automate.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/8e043dd4-22c9-4354-a122-b66b6d992c63) in Chef Automate and click the Approve button.