### PR TITLE
When on Fedora 20+ remap to RHEL 7

### DIFF
--- a/platforms.rb
+++ b/platforms.rb
@@ -114,8 +114,11 @@ end
 
 platform "fedora" do
   remap "el"
-  # FIXME: with some old enough version we should return 5
-  version_remap 6
+  version_remap do |opts|
+    # A combo of Fedora 19/20 was used to create RHEL 7 so when we're on Fedora 20 use the RHEL 7 packages
+    # https://docs.fedoraproject.org/quick-docs/en-US/fedora-and-red-hat-enterprise-linux.html
+    (opts[:version].to_i >= 20) ? "7" : "6"
+  end
 end
 
 platform "linuxmint" do

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -960,6 +960,54 @@ context 'Omnitruck' do
           end
         end
 
+        context 'for fedora' do
+          let(:platform) { 'fedora' }
+
+          context 'for 14 (Arista!)' do
+            let(:platform_version) { '14' }
+
+            context 'for x86_64' do
+              let(:architecture) { 'x86_64' }
+
+              context 'without a version' do
+                let(:project_version) { nil }
+                let(:expected_info) do
+                  {
+                    url: 'https://packages.chef.io/files/stable/chef/13.1.31/el/6/chef-13.1.31-1.el6.x86_64.rpm',
+                    sha256: '31d3c8d09a884a10f93d58c9ead636cfb19b12c9ea6c8de1bb661918347c164d',
+                    sha1: 'a165cae5ea416a32afc5646c5e0a9ac775bc7df4',
+                    version: '13.1.31'
+                  }
+                end
+
+                it_behaves_like 'a correct package info'
+              end
+            end
+          end
+
+          context 'for 28' do
+            let(:platform_version) { '28' }
+
+            context 'for x86_64' do
+              let(:architecture) { 'x86_64' }
+
+              context 'without a version' do
+                let(:project_version) { nil }
+                let(:expected_info) do
+                  {
+                    url: 'https://packages.chef.io/files/stable/chef/13.1.31/el/7/chef-13.1.31-1.el7.x86_64.rpm',
+                    sha256: 'b8397ea2a33a3f4c860daac1cb0714a11d8dad5287b0eb7054e8432d484f9f2c',
+                    sha1: '65c046c91a7186a28af9642e3cffcd72296cf602',
+                    version: '13.1.31'
+                  }
+                end
+
+                it_behaves_like 'a correct package info'
+              end
+            end
+          end
+        end
+
         context 'for ios_xr' do
           let(:platform) { 'ios_xr' }
 


### PR DESCRIPTION
A combo of Fedora 19/20 was used to create RHEL 7 so when we're on Fedora 20 use the RHEL 7 packages. We don't have to worry about RHEL 5 mapping because that's Fedora Core 6 from 11 years ago and if anyone is using that they have bigger problems: It's 20 versions EOL'd.

Signed-off-by: Tim Smith <tsmith@chef.io>