### PR TITLE
Map Amazon 201X.XX to RHEL 6 and 2.X to 7

### DIFF
--- a/platforms.rb
+++ b/platforms.rb
@@ -98,7 +98,7 @@ platform "amazon" do
   version_remap do |opts|
     # map "version 1" amazon linux to RHEL 6. These are named by the year/month ubuntu style
     # map everything else (Amazon Linux 2) to RHEL 7
-    /201\d.\d/.match?(opts[:version]) ? "6" : "7"
+    /201\d\.\d/.match?(opts[:version]) ? "6" : "7"
   end
 end
 

--- a/platforms.rb
+++ b/platforms.rb
@@ -96,7 +96,9 @@ end
 platform "amazon" do
   remap "el"
   version_remap do |opts|
-    (opts[:version].split('.')[0].to_i >= 2) ? "7" : "6"
+    # map "version 1" amazon linux to RHEL 6. These are named by the year/month ubuntu style
+    # map everything else (Amazon Linux 2) to RHEL 7
+    /201\d.\d/.match?(opts[:version]) ? "6" : "7"
   end
 end
 

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -221,6 +221,54 @@ context 'Omnitruck' do
       context 'for stable' do
         let(:channel) { 'stable' }
 
+        context 'for amazon linux' do
+          let(:platform) { 'amazon' }
+
+          context 'for 2018.03' do
+            let(:platform_version) { '2018.03' }
+
+            context 'for x86_64' do
+              let(:architecture) { 'x86_64' }
+
+              context 'without a version' do
+                let(:project_version) { nil }
+                let(:expected_info) do
+                  {
+                    url: 'https://packages.chef.io/files/stable/chef/13.1.31/el/6/chef-13.1.31-1.el6.x86_64.rpm',
+                    sha256: '31d3c8d09a884a10f93d58c9ead636cfb19b12c9ea6c8de1bb661918347c164d',
+                    sha1: 'a165cae5ea416a32afc5646c5e0a9ac775bc7df4',
+                    version: '13.1.31'
+                  }
+                end
+
+                it_behaves_like 'a correct package info'
+              end
+            end
+          end
+
+          context 'for 2' do
+            let(:platform_version) { '2' }
+
+            context 'for x86_64' do
+              let(:architecture) { 'x86_64' }
+
+              context 'without a version' do
+                let(:project_version) { nil }
+                let(:expected_info) do
+                  {
+                    url: 'https://packages.chef.io/files/stable/chef/13.1.31/el/7/chef-13.1.31-1.el7.x86_64.rpm',
+                    sha256: 'b8397ea2a33a3f4c860daac1cb0714a11d8dad5287b0eb7054e8432d484f9f2c',
+                    sha1: '65c046c91a7186a28af9642e3cffcd72296cf602',
+                    version: '13.1.31'
+                  }
+                end
+
+                it_behaves_like 'a correct package info'
+              end
+            end
+          end
+        end
+
         context 'for mac_os_x' do
           let(:platform) { 'mac_os_x' }
 


### PR DESCRIPTION
This goes along with the PR to mixlib-install where we're going pass in
the actual versions for Amazon instead of mapping. Previously we didn't
actually lookup amazon in omnitruck ever. We relied on client side
remapping of the platform and version.

Signed-off-by: Tim Smith <tsmith@chef.io>