### PR TITLE
Don't map xenserver to RHEL 5

### DIFF
--- a/platforms.rb
+++ b/platforms.rb
@@ -104,7 +104,7 @@ end
 #
 platform "xenserver" do
   remap "el"
-  version_remap 5
+  major_only true
 end
 
 platform "coreos" do


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Seth Chisamore

Each xenservers major release is mapped to a major release of RHEL.
They're on 7.X now. This means xenserver users can install Chef 14 now
since we don't have a RHEL 5 build of Chef anymore

Signed-off-by: Tim Smith <tsmith@chef.io>



----
Ready to merge? [View this change](https://automate.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/c742b397-53f7-474d-a0f4-100564875c01) in Chef Automate and click the Approve button.