### PR TITLE
Ensure instances are always t2.medium

### DIFF
--- a/.delivery/build-cookbook/attributes/default.rb
+++ b/.delivery/build-cookbook/attributes/default.rb
@@ -2,6 +2,7 @@
 # systemd for habitat's services.
 default['ciainfra']['image_id'] = 'ami-7ac6491a'
 default['ciainfra']['security_groups'] = ['sg-9d9223f9']
+default['ciainfra']['instance_type'] = 't2.medium'
 
 default['delivery']['project_apps'] = %w(
   omnitruck-app


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Seth Chisamore

Currently the acceptance instances are being provisioned as t2.micro
which is too small to run the application in a stable way. We use
t2.medium instances out in prod so we'll ensure the acceptance instances
match this.

Signed-off-by: Seth Chisamore <schisamo@chef.io>



----
Ready to merge? [View this change](https://automate.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/cde26348-c787-47e0-8680-0666a0655f9e) in Chef Automate and click the Approve button.