### PR TITLE
increase threshold for latency to 1s

### DIFF
--- a/.delivery/build-cookbook/recipes/deploy.rb
+++ b/.delivery/build-cookbook/recipes/deploy.rb
@@ -133,7 +133,7 @@ ruby_block 'Add ELB Monitoring' do
       period: 60,
       unit: "Seconds",
       evaluation_periods: 2,
-      threshold: 0.5,
+      threshold: 1.0,
       comparison_operator: "GreaterThanOrEqualToThreshold",
     })
   end


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Joshua Timberman

The lower threshold unnecessarily notifies us when there isn't a problem that we can fix.

Signed-off-by: Joshua Timberman <joshua@chef.io>



----
Ready to merge? [View this change](https://automate.chef.co/e/chef/#/organizations/CIA/projects/omnitruck/changes/0bf938bc-23fa-40ed-9a08-db5fe82711d1) in Chef Automate and click the Approve button.