### PR TITLE
Remap opensuseleap to SLES

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -340,7 +340,7 @@ class Omnitruck < Sinatra::Base
                      end
                    end
 
-    # SLES/SUSE requests may need to be modified before returning metadata.
+    # SLES/openSUSE requests may need to be modified before returning metadata.
     # If s390x architecture is requested we never modify the metadata.
     if %{sles suse opensuse-leap}.include?(current_platform) && current_arch != "s390x"
       current_platform = 'sles'

--- a/platforms.rb
+++ b/platforms.rb
@@ -59,11 +59,18 @@ platform "darwin" do
   remap "mac_os_x"
 end
 
+# Suse Linux Enterprise Desktop is effectively SLES with a GUI
 platform "sled" do
   major_only true
   remap "sles"
 end
 
+platform "opensuseleap" do
+  major_only true
+  remap "sles"
+end
+
+# this is the legacy name install.sh passed. opensuseleap is the current name
 platform "suse" do
   major_only true
   remap "sles"

--- a/platforms.rb
+++ b/platforms.rb
@@ -59,6 +59,11 @@ platform "darwin" do
   remap "mac_os_x"
 end
 
+# SLES and variants
+#
+# SLES packages work on opensuse and Linux Enterprise Desktop
+#
+
 # Suse Linux Enterprise Desktop is effectively SLES with a GUI
 platform "sled" do
   major_only true
@@ -88,7 +93,7 @@ end
 
 # Supported RHEL Variants
 #
-# These are RHEL clones that we know will work + SuSE that we test on
+# These are RHEL clones that we know will work
 #
 
 platform "centos" do
@@ -162,6 +167,7 @@ platform "raspbian" do
   remap "debian"
 end
 
+# arista is based on an older Fedora release which best maps to EL 6
 platform "arista_eos" do
   major_only true
   remap "el"

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -717,6 +717,18 @@ context 'Omnitruck' do
 
             it_behaves_like 'sles artifacts'
           end
+
+          context 'when opensuseleap' do
+            let(:platform) { 'opensuseleap' }
+
+            it_behaves_like 'sles artifacts'
+          end
+
+          context 'when sled' do
+            let(:platform) { 'sled' }
+
+            it_behaves_like 'sles artifacts'
+          end
         end
 
         context 'for ubuntu' do


### PR DESCRIPTION
suse was never an Ohai platform. It was opensuse, but opensuse releases are now all EOL. The correct platform name here is opensuseleap. This is the first part of aligning our names with Ohai.

Signed-off-by: Tim Smith <tsmith@chef.io>