### PR TITLE
Remap sled -> SLES

### DIFF
--- a/platforms.rb
+++ b/platforms.rb
@@ -59,6 +59,11 @@ platform "darwin" do
   remap "mac_os_x"
 end
 
+platform "sled" do
+  major_only true
+  remap "sles"
+end
+
 platform "suse" do
   major_only true
   remap "sles"


### PR DESCRIPTION
Suse Linux Enterprise Desktop is SLES server with a UI. We're detecting it in Ohai now. install.sh support is in the works.

Signed-off-by: Tim Smith <tsmith@chef.io>