### PR TITLE
Mh/rack env

### DIFF
--- a/habitat/config/config.yml
+++ b/habitat/config/config.yml
@@ -1,3 +1,2 @@
 {{cfg.omnitruck.rack_env}}:
   virtual_path: '{{cfg.omnitruck.virtual_path}}'
-  metadata_dir: '{{pkg.svc_var_path}}{{cfg.omnitruck.metadata_dir}}'

--- a/habitat/config/config.yml
+++ b/habitat/config/config.yml
@@ -1,2 +1,2 @@
-{{cfg.omnitruck.rack_env}}:
+{{cfg.rack_env}}:
   virtual_path: '{{cfg.omnitruck.virtual_path}}'

--- a/habitat/default.toml
+++ b/habitat/default.toml
@@ -1,2 +1,4 @@
+rack_env = "production"
+
 [omnitruck]
 virtual_path = ""


### PR DESCRIPTION
Rack env isn't set at the top level of the habitat config where the scaffolding expects it, and the scaffolding mistakenly auto-adds it under the omnitruck key, so we set it correctly here. We also need to update config.yml as that relied on the incorrect option the scaffolding auto-generated.

While we're here, I removed a metadata_dir reference that should have been removed in a previous PR.