### PR TITLE
Add architecture mapping for arm64 to aarch64

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -333,6 +333,7 @@ class Omnitruck < Sinatra::Base
                    else
                      # Map `uname -m` returned architectures into our internal representations
                      case current_arch
+                     when *%w{ arm64 aarch64 }       then 'aarch64'
                      when *%w{ x86_64 amd64 x64 }    then 'x86_64'
                      when *%w{ i386 x86 i86pc i686 } then 'i386'
                      when *%w{ sparc sun4u sun4v }   then 'sparc'


### PR DESCRIPTION
Signed-off-by: Jaymala Sinha <jsinha@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
Ubuntu nodes map architecutre `uname -i` to aarch64 and `dpkg --print-architecture` to arm64 so we need this mapping reflect here

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
