### PR TITLE
Update mixlib-install to 3.12.1 to support opensuse 15.1+

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
     kgio (2.10.0)
     method_source (0.9.2)
     mime-types (1.25.1)
-    mixlib-install (3.11.29)
+    mixlib-install (3.12.1)
       mixlib-shellout
       mixlib-versioning
       thor


### PR DESCRIPTION
This changes the install.sh script to better parse the version values found in /etc/os-release in a way that fixes install support for opensuse-leap 15.1 and later.

Signed-off-by: Tim Smith <tsmith@chef.io>