### PR TITLE
 Add a new endpoints to support new Product Download site

### DIFF
--- a/.expeditor/buildkite/smoke.sh
+++ b/.expeditor/buildkite/smoke.sh
@@ -13,9 +13,15 @@ elif [ "$TARGET_ENVIRONMENT" == "production" ]; then
   TARGET_DOMAIN="https://omnitruck.chef.io"
 fi
 
+# Core Omnitruck endpoints
 curl --fail -I "$TARGET_DOMAIN/_status"
 curl --fail -I "$TARGET_DOMAIN/install.sh"
 curl --fail -I "$TARGET_DOMAIN/install.ps1"
-curl --fail -I "$TARGET_DOMAIN/stable/chef/versions"
 curl --fail -I "$TARGET_DOMAIN/stable/chef/metadata?p=ubuntu&pv=18.04&m=x86_64"
 curl --fail -I "$TARGET_DOMAIN/stable/chef/download?p=ubuntu&pv=18.04&m=x86_64"
+
+# Download Site endpoints
+curl --fail -I "$TARGET_DOMAIN/stable/chef/versions"
+curl --fail -I "$TARGET_DOMAIN/stable/chef/packages"
+curl --fail -I "$TARGET_DOMAIN/stable/chef/versions/all"
+curl --fail -I "$TARGET_DOMAIN/stable/chef/versions/latest"

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ rspec.failures
 # Bundler-related ignores
 bin/*
 .bundle
+vendor/
 
 # app-specific ignores:
 /build*list.json
@@ -35,3 +36,6 @@ results/
 .kitchen
 
 .delivery/cli.toml
+
+# Redis
+*.rdb

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The values that `p`, `pv` & `m` can take include but are not limited to:
 
 Supports the same options with the `/$channel/$project/metadata` endpoint and instead of returning package information, it returns a redirect to the `"url"` set in the package information.
 
-### `/$channel/$project/versions`
+### `/$channel/$project/packages`
 
 This api is similar to `/$channel/$project/metadata` but instead of returning information about a single package, it returns information about all packages that have the same version number.
 
@@ -107,6 +107,7 @@ Historically omnitruck supported different naming conventions in its endpoints. 
 * /full_$project_list
 * /$project_platform_names
 * /$channel/$project/platforms
+* /$channel/$project/versions
 
 ## Poller
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ This api is similar to `/$channel/$project/metadata` but instead of returning in
 
 Response is an array of objects returned by `/$channel/$project/metadata` endpoint. Supports `v` but does not support `p`, `pv` or `m`.
 
+### `/$channel/$project/versions/all`
+
+Returns a list of available version numbers for a particular channel and project combination
+
+### `/$channel/$project/versions/latest`
+
+Returns the latest version number for a particular channel and project combination
+
 ### `/_status`
 
 Return the status of the application in `json` format.
@@ -102,9 +110,7 @@ Historically omnitruck supported different naming conventions in its endpoints. 
 
 ## Poller
 
-`./poller` is a tool that populates a cache with information about the available versions of Chef packages. In production is runs every 5 minutes with a cron job.
-
-It polls <https://bintray.com/chef> and creates files named `$channel\$project-manifest.json` under the configured metadata directory.
+`./poller` is a tool that populates a Redis cache with information about the available versions of Chef Software, Inc. packages. In production is runs every 5 minutes with a cron job.
 
 ## Version Resolution
 

--- a/app.rb
+++ b/app.rb
@@ -87,12 +87,12 @@ class Omnitruck < Sinatra::Base
     '/metadata' => '/chef/metadata',
     '/download-server' => '/chef-server/download',
     '/metadata-server' => '/chef-server/metadata',
-    '/full_client_list' => '/chef/versions',
-    '/full_list' => '/chef/versions',
-    '/full_server_list' => '/chef-server/versions',
-    '/chef/full_client_list' => '/chef/versions',
-    '/chef/full_list' => '/chef/versions',
-    '/chef/full_server_list' => '/chef-server/versions',
+    '/full_client_list' => '/chef/packages',
+    '/full_list' => '/chef/packages',
+    '/full_server_list' => '/chef-server/packages',
+    '/chef/full_client_list' => '/chef/packages',
+    '/chef/full_list' => '/chef/packages',
+    '/chef/full_server_list' => '/chef-server/packages',
     '/metadata-chefdk' => '/chefdk/metadata',
     '/download-chefdk' => '/chefdk/download',
     '/chef_platform_names' => '/chef/platforms',
@@ -125,7 +125,7 @@ class Omnitruck < Sinatra::Base
   end
 
   get "/full_:project\\_list" do
-    status, headers, body = call env.merge("PATH_INFO" => "/#{project}/versions")
+    status, headers, body = call env.merge("PATH_INFO" => "/#{project}/packages")
     [status, headers, body]
   end
 
@@ -193,20 +193,27 @@ class Omnitruck < Sinatra::Base
 
   get /(?<channel>\/[\w]+)?\/(?<project>[\w-]+)\/versions\/?$/ do
     pass unless project_allowed(project)
+    redirect_url = "/#{channel}/#{project}/packages"
+    redirect_url += "?v=#{params['v']}" unless params['v'].nil?
+    redirect redirect_url, 302
+  end
+
+  get /(?<channel>\/[\w]+)?\/(?<project>[\w-]+)\/packages\/?$/ do
+    pass unless project_allowed(project)
     content_type :json
 
     package_list_info = get_package_list
     JSON.pretty_generate(package_list_info)
   end
 
-  get /(?<channel>\/[\w]+)?\/(?<project>[\w-]+)\/versions\/all\/?$/ do
+  get /(?<channel>\/[\w]+)?\/(?<project>[\w-]+)\/versions\/all/ do
     pass unless project_allowed(project)
     content_type :json
 
     JSON.pretty_generate(available_versions)
   end
 
-  get /(?<channel>\/[\w]+)?\/(?<project>[\w-]+)\/versions\/latest\/?$/ do
+  get /(?<channel>\/[\w]+)?\/(?<project>[\w-]+)\/versions\/latest/ do
     pass unless project_allowed(project)
     content_type :json
 

--- a/app.rb
+++ b/app.rb
@@ -199,6 +199,20 @@ class Omnitruck < Sinatra::Base
     JSON.pretty_generate(package_list_info)
   end
 
+  get /(?<channel>\/[\w]+)?\/(?<project>[\w-]+)\/versions\/all\/?$/ do
+    pass unless project_allowed(project)
+    content_type :json
+
+    JSON.pretty_generate(available_versions)
+  end
+
+  get /(?<channel>\/[\w]+)?\/(?<project>[\w-]+)\/versions\/latest\/?$/ do
+    pass unless project_allowed(project)
+    content_type :json
+
+    JSON.pretty_generate(available_versions.last)
+  end
+
   get /(?<channel>\/[\w]+)?\/(?<project>[\w-]+)\/platforms\/?$/ do
     pass unless project_allowed(project)
 
@@ -291,6 +305,16 @@ class Omnitruck < Sinatra::Base
   #
   def project
     params['project'].gsub('_', '-')
+  end
+
+  #
+  # Returns the available versions for a project and channel
+  #
+  # @return [Array]
+  #   List of available version strings
+  #
+  def available_versions
+    Mixlib::Install.available_versions(project, channel)
   end
 
   #

--- a/lib/chef/project_manifest.rb
+++ b/lib/chef/project_manifest.rb
@@ -102,7 +102,7 @@ class Chef
     end
 
     #
-    # This method generates a project manifest using info from Bintray.
+    # This method generates a project manifest using info from packages.chef.io
     #
     # @return [ProjectManifest]
     #

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -1351,9 +1351,7 @@ context 'Omnitruck' do
   end
 
   context '/<CHANNEL>/<PROJECT>/packages endpoint' do
-    # TODO: change this back once Chef Workstation hits stable!
-    # Chef::Cache::KNOWN_PROJECTS.each do |project|
-    (Chef::Cache::KNOWN_PROJECTS - ['chef-workstation']).each do |project|
+    real_projects.each do |project|
       context "for #{project}" do
         let(:endpoint){ "/stable/#{project}/packages" }
 
@@ -1454,6 +1452,47 @@ context 'Omnitruck' do
         metadata_json = last_response.body
         JSON.parse(metadata_json)
       }
+    end
+  end
+
+  context '/<CHANNEL>/<PROJECT>/versions/all endpoint' do
+    real_projects.each do |project|
+      context "for #{project}" do
+        let(:endpoint){ "/stable/#{project}/versions/all" }
+
+        it "exists" do
+          get(endpoint)
+          expect(last_response).to be_ok
+        end
+
+        it "returns the correct JSON data" do
+          get(endpoint)
+          expect(last_response.header['Content-Type']).to include 'application/json'
+          response = JSON.parse(last_response.body)
+          expect(response).to be_an_instance_of(Array)
+          expect(response.length).to be > 1
+        end
+      end
+    end
+  end
+
+  context '/<CHANNEL>/<PROJECT>/versions/latest endpoint' do
+    real_projects.each do |project|
+      context "for #{project}" do
+        let(:endpoint){ "/stable/#{project}/versions/latest" }
+
+        it "exists" do
+          get(endpoint)
+          expect(last_response).to be_ok
+        end
+
+        it "returns the correct JSON data" do
+          get(endpoint)
+          expect(last_response.header['Content-Type']).to include 'application/json'
+          response = JSON.parse(last_response.body)
+          expect(response).to be_an_instance_of(String)
+        end
+      end
     end
   end
 

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -1350,12 +1350,12 @@ context 'Omnitruck' do
 
   end
 
-  context '/<CHANNEL>/<PROJECT>/versions endpoint' do
+  context '/<CHANNEL>/<PROJECT>/packages endpoint' do
     # TODO: change this back once Chef Workstation hits stable!
     # Chef::Cache::KNOWN_PROJECTS.each do |project|
     (Chef::Cache::KNOWN_PROJECTS - ['chef-workstation']).each do |project|
       context "for #{project}" do
-        let(:endpoint){ "/stable/#{project}/versions" }
+        let(:endpoint){ "/stable/#{project}/packages" }
 
         it "exists" do
           get(endpoint)
@@ -1376,7 +1376,7 @@ context 'Omnitruck' do
     # Let's test with chefdk because chef manifest have a 12.6.1 entry in it which
     # limits the information we are getting out of this endpoint.
     context "for stable chefdk" do
-      let(:endpoint) { '/stable/chefdk/versions' }
+      let(:endpoint) { '/stable/chefdk/packages' }
       let(:params) { { v: version } }
       let(:versions_output) {
         get(endpoint, params)
@@ -1447,7 +1447,7 @@ context 'Omnitruck' do
     end
 
     context "for current chefdk" do
-      let(:endpoint) { '/current/chefdk/versions' }
+      let(:endpoint) { '/current/chefdk/packages' }
       let(:params) { { v: version } }
       let(:versions_output) {
         get(endpoint, params)

--- a/spec/data/stable/chef-workstation-manifest.json
+++ b/spec/data/stable/chef-workstation-manifest.json
@@ -1,0 +1,108 @@
+{
+    "ubuntu": {
+      "16.04": {
+        "x86_64": {
+          "sha1": "5d89b5c2b2c86980b18e6114066802d554188683",
+          "sha256": "c447bdc246312dd8883cd61894da60c28405efb2904240eca4a3fd9c4122fb3a",
+          "url": "https://packages.chef.io/files/stable/chef-workstation/0.16.33/ubuntu/16.04/chef-workstation_0.16.33-1_amd64.deb",
+          "version": "0.16.33"
+        }
+      },
+      "18.04": {
+        "x86_64": {
+          "sha1": "5d89b5c2b2c86980b18e6114066802d554188683",
+          "sha256": "c447bdc246312dd8883cd61894da60c28405efb2904240eca4a3fd9c4122fb3a",
+          "url": "https://packages.chef.io/files/stable/chef-workstation/0.16.33/ubuntu/18.04/chef-workstation_0.16.33-1_amd64.deb",
+          "version": "0.16.33"
+        }
+      }
+    },
+    "el": {
+      "6": {
+        "x86_64": {
+          "sha1": "36dc2460427bd4856e3a3a247747ebe25d8f545f",
+          "sha256": "60377244bf500e5324a2c80ef3dc4a5e82fcae12d20626fdf22324b9e14ddecd",
+          "url": "https://packages.chef.io/files/stable/chef-workstation/0.16.33/el/6/chef-workstation-0.16.33-1.el6.x86_64.rpm",
+          "version": "0.16.33"
+        }
+      },
+      "7": {
+        "x86_64": {
+          "sha1": "f6ac8f616624b41b9328149ab6a9fdd31a1466e5",
+          "sha256": "a5e816c712fa90ac044c048d892f147274fafa5a6db070200a4945f6dc1e12b2",
+          "url": "https://packages.chef.io/files/stable/chef-workstation/0.16.33/el/7/chef-workstation-0.16.33-1.el7.x86_64.rpm",
+          "version": "0.16.33"
+        }
+      },
+      "8": {
+        "x86_64": {
+          "sha1": "f6ac8f616624b41b9328149ab6a9fdd31a1466e5",
+          "sha256": "a5e816c712fa90ac044c048d892f147274fafa5a6db070200a4945f6dc1e12b2",
+          "url": "https://packages.chef.io/files/stable/chef-workstation/0.16.33/el/8/chef-workstation-0.16.33-1.el7.x86_64.rpm",
+          "version": "0.16.33"
+        }
+      }
+    },
+    "mac_os_x": {
+      "10.13": {
+        "x86_64": {
+          "sha1": "d87acebcf448cbbfbc20ce0863e963c93735627a",
+          "sha256": "73ae4f3a6a22431d7d51f0a633121d1a2de65b4af9d3034ac7585cb9331711db",
+          "url": "https://packages.chef.io/files/stable/chef-workstation/0.16.33/mac_os_x/10.13/chef-workstation-0.16.33-1.dmg",
+          "version": "0.16.33"
+        }
+      },
+      "10.14": {
+        "x86_64": {
+          "sha1": "d87acebcf448cbbfbc20ce0863e963c93735627a",
+          "sha256": "73ae4f3a6a22431d7d51f0a633121d1a2de65b4af9d3034ac7585cb9331711db",
+          "url": "https://packages.chef.io/files/stable/chef-workstation/0.16.33/mac_os_x/10.14/chef-workstation-0.16.33-1.dmg",
+          "version": "0.16.33"
+        }
+      },
+      "10.15": {
+        "x86_64": {
+          "sha1": "d87acebcf448cbbfbc20ce0863e963c93735627a",
+          "sha256": "73ae4f3a6a22431d7d51f0a633121d1a2de65b4af9d3034ac7585cb9331711db",
+          "url": "https://packages.chef.io/files/stable/chef-workstation/0.16.33/mac_os_x/10.15/chef-workstation-0.16.33-1.dmg",
+          "version": "0.16.33"
+        }
+      }
+    },
+    "windows": {
+      "2008r2": {
+        "x86_64": {
+          "sha1": "80ef10011ca6d170fe874612c9f3d64291824ad8",
+          "sha256": "8556fab7e35cc14f67bc78867722b165adfd1403bdba7314cc894509c77afebd",
+          "url": "https://packages.chef.io/files/stable/chef-workstation/0.16.33/windows/2019/chef-workstation-0.16.33-1-x64.msi",
+          "version": "0.16.33"
+        }
+      }
+    },
+    "debian": {
+      "9": {
+        "x86_64": {
+          "sha1": "29a13385be79d7ed6e3af1fae7417b3ce60e6a9f",
+          "sha256": "3db05ca26e0b64b5c5a1c198d40036b297729e56b2f60e22243a06ab7699dfc0",
+          "url": "https://packages.chef.io/files/stable/chef-workstation/0.16.33/debian/9/chef-workstation_0.16.33-1_amd64.deb",
+          "version": "0.16.33"
+        }
+      },
+      "8": {
+        "x86_64": {
+          "sha1": "29a13385be79d7ed6e3af1fae7417b3ce60e6a9f",
+          "sha256": "3db05ca26e0b64b5c5a1c198d40036b297729e56b2f60e22243a06ab7699dfc0",
+          "url": "https://packages.chef.io/files/stable/chef-workstation/0.16.33/debian/8/chef-workstation_0.16.33-1_amd64.deb",
+          "version": "0.16.33"
+        }
+      },
+      "10": {
+        "x86_64": {
+          "sha1": "29a13385be79d7ed6e3af1fae7417b3ce60e6a9f",
+          "sha256": "3db05ca26e0b64b5c5a1c198d40036b297729e56b2f60e22243a06ab7699dfc0",
+          "url": "https://packages.chef.io/files/stable/chef-workstation/0.16.33/debian/10/chef-workstation_0.16.33-1_amd64.deb",
+          "version": "0.16.33"
+        }
+      }
+    }
+  }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,6 +41,18 @@ RSpec.configure do |conf|
     c.syntax = :expect
   end
 
+  def real_projects
+    @real_projects ||= (
+      Chef::Cache::KNOWN_PROJECTS - [
+        'chef-server-ha-provisioning',
+        'ha',
+        'harmony',
+        'mac-bootstrapper',
+        'omnibus-gcc',
+        'sync',
+      ])
+  end
+
   # Uncomment to write failed specs to file.
   # Run failed tests using --only-failures flag
   # conf.example_status_persistence_file_path = "examples.txt"


### PR DESCRIPTION
- New endpoints:
  - `/$channel/$project/versions/all` - Returns a list of available version numbers for a particular channel and project combination
  - `/$channel/$project/versions/latest` - Returns the latest version number for a particular channel and project combination
- Deprecate poorly named `/$channel/$project/versions` endpoint. We'll redirect the old endpoint to a more properly named `/$channel/$project/packages` endpoint.

Signed-off-by: Seth Chisamore <schisamo@chef.io>

