### PR TITLE
Add `/architectures` endpoint which returns valid machine architectures

### DIFF
--- a/.expeditor/buildkite/smoke.sh
+++ b/.expeditor/buildkite/smoke.sh
@@ -15,6 +15,9 @@ fi
 
 # Core Omnitruck endpoints
 curl --fail -I "$TARGET_DOMAIN/_status"
+curl --fail -I "$TARGET_DOMAIN/products"
+curl --fail -I "$TARGET_DOMAIN/platforms"
+curl --fail -I "$TARGET_DOMAIN/architectures"
 curl --fail -I "$TARGET_DOMAIN/install.sh"
 curl --fail -I "$TARGET_DOMAIN/install.ps1"
 curl --fail -I "$TARGET_DOMAIN/stable/chef/metadata?p=ubuntu&pv=18.04&m=x86_64"

--- a/app.rb
+++ b/app.rb
@@ -134,6 +134,17 @@ class Omnitruck < Sinatra::Base
     [status, headers, body]
   end
 
+  get /(?<channel>\/[\w]+)?\/(?<project>[\w-]+)\/versions\/?$/ do
+    pass unless project_allowed(project)
+    redirect_url = "/#{channel}/#{project}/packages"
+    redirect_url += "?v=#{params['v']}" unless params['v'].nil?
+    redirect redirect_url, 302
+  end
+
+  get /(?<channel>\/[\w]+)?\/(?<project>[\w-]+)\/platforms/ do
+    pass unless project_allowed(project)
+    redirect '/platforms', 302
+  end
   #########################################################################
   # END LEGACY REDIRECTS
   #########################################################################
@@ -191,13 +202,6 @@ class Omnitruck < Sinatra::Base
     end
   end
 
-  get /(?<channel>\/[\w]+)?\/(?<project>[\w-]+)\/versions\/?$/ do
-    pass unless project_allowed(project)
-    redirect_url = "/#{channel}/#{project}/packages"
-    redirect_url += "?v=#{params['v']}" unless params['v'].nil?
-    redirect redirect_url, 302
-  end
-
   get /(?<channel>\/[\w]+)?\/(?<project>[\w-]+)\/packages\/?$/ do
     pass unless project_allowed(project)
     content_type :json
@@ -220,12 +224,17 @@ class Omnitruck < Sinatra::Base
     JSON.pretty_generate(available_versions.last)
   end
 
-  get /(?<channel>\/[\w]+)?\/(?<project>[\w-]+)\/platforms/ do
-    pass unless project_allowed(project)
-    redirect '/platforms', 302
+  get /architectures/ do
+    content_type :json
+
+    JSON.pretty_generate(
+      Mixlib::Install::Options::SUPPORTED_ARCHITECTURES
+    )
   end
 
   get /platforms/ do
+    content_type :json
+
     JSON.pretty_generate({
       "aix"       => "AIX",
       "el"        => "Red Hat Enterprise Linux/CentOS",

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -27,13 +27,31 @@ context 'Omnitruck' do
     Omnitruck
   end
 
-  context "products endpoint" do
+  context "/products endpoint" do
     it "returns all the products" do
       get("/products")
 
       response = JSON.parse(last_response.body)
       Chef::Cache::KNOWN_PROJECTS.each do |project|
         response.include?(project)
+      end
+    end
+  end
+
+  context "/platforms endpoint" do
+    it "returns JSON data" do
+      get("/platforms")
+      expect(last_response.header['Content-Type']).to include 'application/json'
+    end
+  end
+
+  context "/architectures endpoint" do
+    it "returns all the architectures" do
+      get("/architectures")
+
+      response = JSON.parse(last_response.body)
+      Mixlib::Install::Options::SUPPORTED_ARCHITECTURES.each do |arch|
+        response.include?(arch)
       end
     end
   end


### PR DESCRIPTION
Signed-off-by: Seth Chisamore <schisamo@chef.io>
