### PR TITLE
Retry smoke tests 1 time on deployment

### DIFF
--- a/.expeditor/deploy.pipeline.yml
+++ b/.expeditor/deploy.pipeline.yml
@@ -39,6 +39,9 @@ steps:
     label: ":expeditor:"
     concurrency: 1
     concurrency_group: chef-omnitruck-master/deploy/$ENVIRONMENT
+    retry:
+      automatic:
+        limit: 1
     expeditor:
       executor:
         docker:


### PR DESCRIPTION
Sometimes we hit a slight race condition on deployments. We'll automatically retry our
smoke tests one time to get past this.

Signed-off-by: Seth Chisamore <schisamo@chef.io>
