### PR TITLE
Ensure omnitruck-poller starts with the correct Ruby

### DIFF
--- a/kubernetes/deployment.yml
+++ b/kubernetes/deployment.yml
@@ -73,7 +73,7 @@ spec:
           - image: chefops/<%= ENV['APP'] %>:<%= ENV['IMAGE_TAG'] %>
             name: <%= ENV['APP'] %>-poller
             command: ['/bin/sh']
-            args: ['-c', 'cd $(hab pkg path chefops/<%= ENV['APP'] %>)/app; bundle exec $(hab pkg path core/ruby24)/bin/ruby ./poller 2>&1']
+            args: ['-c', 'cd $(hab pkg path chefops/<%= ENV['APP'] %>)/app; bundle exec $(hab pkg path core/ruby)/bin/ruby ./poller 2>&1']
             env:
               - name: HAB_LICENSE
                 value: accept-no-persist


### PR DESCRIPTION
Back in #440 we switched from depending on `core/ruby24` and moved to
depending on `core/ruby`. We missed updating this Kubernetes deployment
script.

Signed-off-by: Seth Chisamore <schisamo@chef.io>
