### PR TITLE
Remove Habitat operator, update k8s deployment

### DIFF
--- a/.expeditor/deploy.pipeline.yml
+++ b/.expeditor/deploy.pipeline.yml
@@ -9,7 +9,7 @@ steps:
       executor:
         docker:
       secrets:
-        AWS_SSL_INTERNAL_ARN:
+        AWS_SSL_ARN:
           path: secret/chefops/aws
           field: ssl_internal_arn
         DOCKER_CONFIG_JSON_CHEFOPS:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,4 +119,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/kubernetes/deployment.yml
+++ b/kubernetes/deployment.yml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -5,7 +6,6 @@ metadata:
 ---
 apiVersion: v1
 data:
-  # base64 encoded string of the config.json contents
   .dockerconfigjson: <%= ENV['DOCKER_CONFIG_JSON_CHEFOPS'] %>
 kind: Secret
 metadata:
@@ -14,49 +14,111 @@ metadata:
 type: kubernetes.io/dockerconfigjson
 ---
 apiVersion: v1
-kind: ServiceAccount
+kind: Service
 metadata:
-  name: default
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
+    <%- if ENV['ENVIRONMENT'] == 'production' -%>
+    service.beta.kubernetes.io/aws-load-balancer-access-log-enabled: "true"
+    service.beta.kubernetes.io/aws-load-balancer-access-log-emit-interval: "60"
+    service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name: "chef-utility-kubernetes-elb-access-logs"
+    service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix: "<%= ENV['APP'] %>-<%= ENV['ENVIRONMENT'] %>"
+    <%- end -%>
+    <%- if ENV.has_key?('AWS_SSL_ARN') -%>
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: <%= ENV['AWS_SSL_ARN'] %>
+    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
+    <%- end -%>
+    dns.alpha.kubernetes.io/external: "<%= ENV['APP'] %>-<%= ENV['ENVIRONMENT'] %>.kubernetes.chef.co"
+  labels:
+    run: <%= ENV['APP'] %>-<%= ENV['ENVIRONMENT'] %>
+    dns: route53
+  name: <%= ENV['APP'] %>-<%= ENV['ENVIRONMENT'] %>
   namespace: <%= ENV['APP'] %>
-imagePullSecrets:
-- name: registry-secret
+spec:
+  ports:
+  <%- if ENV.has_key?('AWS_SSL_ARN') -%>
+  - name: https
+    port: 443
+  <%- else -%>
+  - name: http
+    port: 80
+    <%- end -%>
+    protocol: TCP
+    targetPort: 8000
+  selector:
+    run: <%= ENV['APP'] %>-<%= ENV['ENVIRONMENT'] %>
+  sessionAffinity: None
+  type: LoadBalancer
 ---
-apiVersion: v1
-kind: ServiceAccount
+apiVersion: extensions/v1beta1
+kind: Deployment
 metadata:
-  name: habitat-operator
+  annotations:
+    deployment.kubernetes.io/revision: "2"
+  labels:
+    run: <%= ENV['APP'] %>-<%= ENV['ENVIRONMENT'] %>
+  name: <%= ENV['APP'] %>-<%= ENV['ENVIRONMENT'] %>
   namespace: <%= ENV['APP'] %>
-# use the secret defined earlier
-imagePullSecrets:
-- name: registry-secret
+spec:
+  replicas: <%= ENV['ENVIRONMENT'] == 'production' ? '4': '2' %>
+  selector:
+    matchLabels:
+      run: <%= ENV['APP'] %>-<%= ENV['ENVIRONMENT'] %>
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        run: <%= ENV['APP'] %>-<%= ENV['ENVIRONMENT'] %>
+    spec:
+      containers:
+      - name: <%= ENV['APP'] %>-<%= ENV['ENVIRONMENT'] %>
+        image: chefops/<%= ENV['APP'] %>:<%= ENV['IMAGE_TAG'] %>
+        env:
+          - name: HAB_LICENSE
+            value: accept-no-persist
+          - name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                name: <%= ENV['APP'] %>-<%= ENV['ENVIRONMENT'] == 'production' ? 'production' : 'nonproduction' %>
+                key: redis_url
+        ports:
+        - containerPort: 8000
+          protocol: TCP
+        - containerPort: 9631
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        <%- unless ENV['ENVIRONMENT'] == 'production' -%>
+        imagePullPolicy: Always
+        <%- end -%>
+      imagePullSecrets:
+      - name: registry-secret
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+
 ---
-apiVersion: habitat.sh/v1beta1
-kind: Habitat
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
 metadata:
   name: <%= ENV['APP'] %>-<%= ENV['ENVIRONMENT'] %>
   namespace: <%= ENV['APP'] %>
-  # this gets translated to "habitat-name" by the operator,
-  # and is used in the Service resource label (see below)
-  labels:
-    app: <%= ENV['APP'] %>-<%= ENV['ENVIRONMENT'] %>
-customVersion: v1beta2
 spec:
-  v1beta2:
-    image: chefops/<%= ENV['APP'] %>:<%= ENV['IMAGE_TAG'] %>
-    count: <%= ENV['ENVIRONMENT'] == 'production' ? '3' : '2' %>
-    env:
-      - name: HAB_LICENSE
-        value: accept-no-persist
-      - name: REDIS_URL
-        valueFrom:
-          secretKeyRef:
-            name: <%= ENV['APP'] %>-<%= ENV['ENVIRONMENT'] %>
-            key: redis_url
-    service:
-      name: <%= ENV['APP'] %>
-      topology: standalone
-      # Not needed because we don't change anything any more
-      #configSecretName: <%= ENV['APP'] %>-<%= ENV['ENVIRONMENT'] == 'production' ? ENV['ENVIRONMENT'] : 'nonproduction' %>
+  maxReplicas: 10
+  minReplicas: 2
+  scaleTargetRef:
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    name: <%= ENV['APP'] %>-<%= ENV['ENVIRONMENT'] %>
+  targetCPUUtilizationPercentage: 80
 ---
 apiVersion: batch/v1beta1
 kind: CronJob
@@ -80,43 +142,6 @@ spec:
               - name: REDIS_URL
                 valueFrom:
                   secretKeyRef:
-                    name: <%= ENV['APP'] %>-<%= ENV['ENVIRONMENT'] %>
+                    name: <%= ENV['APP'] %>-<%= ENV['ENVIRONMENT'] == 'production' ? 'production' : 'nonproduction' %>
                     key: redis_url
           restartPolicy: OnFailure
----
-apiVersion: v1
-kind: Service
-metadata:
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
-    <%- if ENV['ENVIRONMENT'] == 'production' -%>
-    service.beta.kubernetes.io/aws-load-balancer-access-log-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-access-log-emit-interval: "60"
-    service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name: "chef-utility-kubernetes-elb-access-logs"
-    service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix: "<%= ENV['APP'] %>-<%= ENV['ENVIRONMENT'] %>"
-    <%- end -%>
-    <%- if ENV.has_key?('AWS_SSL_INTERNAL_ARN') -%>
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: <%= ENV['AWS_SSL_INTERNAL_ARN'] %>
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
-    <%- end -%>
-    dns.alpha.kubernetes.io/external: "<%= ENV['APP'] %>-<%= ENV['ENVIRONMENT'] %>.kubernetes.chef.co"
-  labels:
-    run: <%= ENV['APP'] %>-<%= ENV['ENVIRONMENT'] %>
-    dns: route53
-  name: <%= ENV['APP'] %>-<%= ENV['ENVIRONMENT'] %>
-  namespace: <%= ENV['APP'] %>
-spec:
-  ports:
-  <%- if ENV.has_key?('AWS_SSL_INTERNAL_ARN') -%>
-  - name: https
-    port: 443
-  <%- else -%>
-  - name: http
-    port: 80
-  <%- end -%>
-    protocol: TCP
-    targetPort: 8000
-  selector:
-    habitat-name: <%= ENV['APP'] %>-<%= ENV['ENVIRONMENT'] %>
-  sessionAffinity: None
-  type: LoadBalancer

--- a/kubernetes/deployment.yml
+++ b/kubernetes/deployment.yml
@@ -94,6 +94,12 @@ spec:
         resources: {}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+        livenessProbe:
+          httpGet:
+            path: /_status
+            port: 8000
+          initialDelaySeconds: 3
+          periodSeconds: 3
         <%- unless ENV['ENVIRONMENT'] == 'production' -%>
         imagePullPolicy: Always
         <%- end -%>


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
The habitat operator is no longer supported, this change converts to a standard `Deployment`  / `HorizontalPodAutoscaler` model.  Additionally, we standardize a few environment variables with Ops templates, and add a missing pod LivenessProbe to address OPS-1292 and update Bundler to make the hab build happy.

## Related Issue
OPS-1292
OPS-1385

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
