### PR TITLE
chef-foundation tuned for SLES

### DIFF
--- a/lib/dist.rb
+++ b/lib/dist.rb
@@ -8,6 +8,7 @@ module OmnitruckDist
   SLES_PROJECT_VERSIONS = {
     "automate" => "0.8.5",
     "chef" => "12.21.1",
+    "chef-foundation" => "0.0.0",
     "angrychef" => "12.21.1",
     "chef-server" => "12.14.0",
     "chefdk" => "1.3.43",


### PR DESCRIPTION
## Description
In line with `chef` artefacts, `chef-foundation` too supports SLES native packages right from start. This update keeps `chef-foundation` in tune with `chef` when package metadata is fetched.

Without this fix, the [URL](https://omnitruck.chef.io/current/chef-foundation/metadata?v=3.0.6&p=sles&pv=12&m=aarch64) to SLES `aarch64` package would return a 404
& the [URL](https://omnitruck.chef.io/current/chef-foundation/metadata?v=3.0.6&p=sles&pv=15&m=x86_64) to fetch SLES `x86_64` would return the RHEL package metadata as fallback.

With this fix, the native SLES package metadata is returned as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
