### PR TITLE
CHEF-29762 add license_id parameter to install scripts call

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -7,7 +7,9 @@ expeditor:
 steps:
   - label: ":ruby: unit"
     command:
-      - bundle install --binstubs --path=vendor/bundle
+      - bundle config set --local path 'vendor/bundle'
+      - bundle install
+      - bundle binstubs --all
       - bundle exec rspec
     expeditor:
       executor:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1.6-alpine
+FROM ruby:3.4.9-alpine
 
 LABEL maintainer="releng@chef.io"
 
@@ -32,4 +32,4 @@ WORKDIR $APP_ROOT
 
 USER releng
 
-CMD bundle exec unicorn
+CMD bundle exec puma

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "rest-client"
 gem 'rake'
 gem 'redis'
 gem 'mixlib-versioning', '~> 1.1.0'
-gem "mixlib-install", '>= 3.15.0', git: "https://github.com/chef/mixlib-install", branch: "package-manager" # TODO: bump version and remove the git reference once this PR is merged: https://github.com/chef/mixlib-install/pull/417
+gem "mixlib-install", '>= 3.16.0' # 3.16.0+ is required for new chef-ice product support
 gem 'trashed'
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "rest-client"
 gem 'rake'
 gem 'redis'
 gem 'mixlib-versioning', '~> 1.1.0'
-gem "mixlib-install", '>= 3.14.0', git: "https://github.com/chef/mixlib-install", branch: "package-manager" # TODO: remove the git reference once this PR is merged: https://github.com/chef/mixlib-install/pull/417
+gem "mixlib-install", '>= 3.15.0', git: "https://github.com/chef/mixlib-install", branch: "package-manager" # TODO: bump version and remove the git reference once this PR is merged: https://github.com/chef/mixlib-install/pull/417
 gem 'trashed'
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "rest-client"
 gem 'rake'
 gem 'redis'
 gem 'mixlib-versioning', '~> 1.1.0'
-gem "mixlib-install", '>= 3.14.0', git: "https://github.com/chef/mixlib-install", branch: "check-install"
+gem "mixlib-install", '>= 3.14.0', git: "https://github.com/chef/mixlib-install", branch: "package-manager" # TODO: remove the git reference once this PR is merged: https://github.com/chef/mixlib-install/pull/417
 gem 'trashed'
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "rest-client"
 gem 'rake'
 gem 'redis'
 gem 'mixlib-versioning', '~> 1.1.0'
-gem "mixlib-install", '>= 3.11.23', git: "https://github.com/chef/mixlib-install", branch: "main"
+gem "mixlib-install", '>= 3.14.0', git: "https://github.com/chef/mixlib-install", branch: "check-install"
 gem 'trashed'
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,18 @@
 source 'https://rubygems.org'
 
-gem 'sinatra', '>= 1.4', '< 2'
+gem 'sinatra'
 gem 'sinatra-contrib'
 gem 'sinatra-cors'
 gem 'sinatra-param'
-gem 'unicorn'
+gem 'puma'
 gem 'json'
 gem 'colorize'
 gem 'yajl-ruby'
-gem "rest-client"
+gem 'rest-client'
 gem 'rake'
 gem 'redis'
+gem 'statsd-ruby'
+gem 'trashed'
 gem 'mixlib-versioning', '>= 1.1.0'
 # 3.17.0+ is required for new chef-ice and inspec-enterprise product support
 gem 'mixlib-install', '>= 3.17.0'
@@ -23,5 +25,4 @@ group :test do
   gem 'rack-test'
   gem 'rspec_junit_formatter'
   gem 'pry-byebug'
-  gem 'rb-readline'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'sinatra', '~> 1.4', '< 2'
+gem 'sinatra', '>= 1.4', '< 2'
 gem 'sinatra-contrib'
 gem 'sinatra-cors'
 gem 'sinatra-param'
@@ -11,14 +11,15 @@ gem 'yajl-ruby'
 gem "rest-client"
 gem 'rake'
 gem 'redis'
-gem 'mixlib-versioning', '~> 1.1.0'
-gem "mixlib-install", '>= 3.16.0' # 3.16.0+ is required for new chef-ice product support
+gem 'mixlib-versioning', '>= 1.1.0'
+# 3.16.0+ is required for new chef-ice product support
+gem 'mixlib-install', '>= 3.16.0', git: 'https://github.com/chef/mixlib-install.git', branch: 'pm-optional'
 gem 'trashed'
 
 group :test do
   gem 'rspec'
   gem 'rspec-legacy_formatters'
-  gem 'rspec-rerun', '~> 1.1.0'
+  gem 'rspec-rerun', '>= 1.1.0'
   gem 'rspec-its'
   gem 'rack-test'
   gem 'rspec_junit_formatter'

--- a/Gemfile
+++ b/Gemfile
@@ -12,9 +12,8 @@ gem "rest-client"
 gem 'rake'
 gem 'redis'
 gem 'mixlib-versioning', '>= 1.1.0'
-# 3.16.0+ is required for new chef-ice product support
-gem 'mixlib-install', '>= 3.16.0', git: 'https://github.com/chef/mixlib-install.git', branch: 'pm-optional'
-gem 'trashed'
+# 3.17.0+ is required for new chef-ice and inspec-enterprise product support
+gem 'mixlib-install', '>= 3.17.0'
 
 group :test do
   gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/chef/mixlib-install
-  revision: 1c3261ef68c3ba1ba3a380d04b617d7d99a0f3ff
-  branch: main
+  revision: 2addca5ad7736d5661e1294dd0fb1f5606a65d9a
+  branch: check-install
   specs:
-    mixlib-install (3.12.30)
+    mixlib-install (3.14.0)
       mixlib-shellout
       mixlib-versioning
       thor
@@ -13,11 +13,11 @@ GEM
   specs:
     backports (3.20.2)
     byebug (11.1.3)
-    chef-utils (18.3.0)
+    chef-utils (18.9.4)
       concurrent-ruby
     coderay (1.1.3)
     colorize (0.8.1)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.3.6)
     diff-lcs (1.4.4)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
@@ -30,7 +30,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0212)
-    mixlib-shellout (3.2.7)
+    mixlib-shellout (3.3.9)
       chef-utils
     mixlib-versioning (1.1.0)
     multi_json (1.15.0)
@@ -92,7 +92,7 @@ GEM
     sinatra-param (1.6.0)
       sinatra (>= 1.3)
     statsd-ruby (1.5.0)
-    thor (1.3.0)
+    thor (1.5.0)
     tilt (2.0.10)
     trashed (3.2.7)
       statsd-ruby (~> 1.1)
@@ -110,7 +110,7 @@ PLATFORMS
 DEPENDENCIES
   colorize
   json
-  mixlib-install (>= 3.11.23)!
+  mixlib-install (>= 3.14.0)!
   mixlib-versioning (~> 1.1.0)
   pry-byebug
   rack-test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/chef/mixlib-install
-  revision: 2addca5ad7736d5661e1294dd0fb1f5606a65d9a
-  branch: check-install
+  revision: da50e201710530b9ccd5204a65779ad3a64116d3
+  branch: package-manager
   specs:
-    mixlib-install (3.14.0)
+    mixlib-install (3.15.0)
       mixlib-shellout
       mixlib-versioning
       thor

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,22 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    backports (3.25.3)
-    byebug (12.0.0)
+    base64 (0.3.0)
+    byebug (13.0.0)
+      reline (>= 0.6.0)
     chef-utils (19.3.15)
       concurrent-ruby
     coderay (1.1.3)
     colorize (1.1.0)
     concurrent-ruby (1.3.6)
-    connection_pool (2.5.5)
+    connection_pool (3.0.2)
     diff-lcs (1.6.2)
     domain_name (0.6.20240107)
     http-accept (1.7.0)
     http-cookie (1.1.6)
       domain_name (~> 0.5)
-    json (2.19.7)
-    kgio (2.11.4)
+    io-console (0.8.2)
+    json (2.19.8)
     logger (1.7.0)
     method_source (1.1.0)
     mime-types (3.7.0)
@@ -30,27 +31,37 @@ GEM
     mixlib-shellout (3.4.10)
       chef-utils
     mixlib-versioning (1.2.12)
-    multi_json (1.19.1)
+    multi_json (1.21.1)
+    mustermann (3.1.1)
     netrc (0.11.0)
+    nio4r (2.7.5)
     ostruct (0.6.3)
-    pry (0.15.2)
+    pry (0.16.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.11.0)
-      byebug (~> 12.0)
-      pry (>= 0.13, < 0.16)
-    rack (1.6.13)
-    rack-protection (1.5.5)
-      rack
+      reline (>= 0.6.0)
+    pry-byebug (3.12.0)
+      byebug (~> 13.0)
+      pry (>= 0.13, < 0.17)
+    puma (8.0.2)
+      nio4r (~> 2.0)
+    rack (3.2.6)
+    rack-protection (4.2.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.1.2)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
     rack-test (2.2.0)
       rack (>= 1.3)
-    raindrops (0.20.1)
     rake (13.4.2)
-    rb-readline (0.5.5)
     redis (5.4.1)
       redis-client (>= 0.22.0)
     redis-client (0.29.0)
       connection_pool
+    reline (0.6.3)
+      io-console (~> 0.5)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
@@ -78,29 +89,33 @@ GEM
     rspec-support (3.13.7)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
-    sinatra (1.4.8)
-      rack (~> 1.5)
-      rack-protection (~> 1.4)
-      tilt (>= 1.3, < 3)
-    sinatra-contrib (1.4.7)
-      backports (>= 2.0)
-      multi_json
-      rack-protection
-      rack-test
-      sinatra (~> 1.4.0)
-      tilt (>= 1.3, < 3)
+    sinatra (4.2.1)
+      logger (>= 1.6.0)
+      mustermann (~> 3.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.2.1)
+      rack-session (>= 2.0.0, < 3)
+      tilt (~> 2.0)
+    sinatra-contrib (4.2.1)
+      multi_json (>= 0.0.2)
+      mustermann (~> 3.0)
+      rack-protection (= 4.2.1)
+      sinatra (= 4.2.1)
+      tilt (~> 2.0)
     sinatra-cors (1.2.0)
     sinatra-param (1.6.0)
       sinatra (>= 1.3)
+    statsd-ruby (1.5.0)
     thor (1.5.0)
     tilt (2.7.0)
-    unicorn (6.1.0)
-      kgio (~> 2.6)
-      raindrops (~> 0.7)
+    trashed (3.2.8)
+      statsd-ruby (~> 1.1)
     yajl-ruby (1.4.3)
 
 PLATFORMS
+  arm64-darwin-25
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   colorize
@@ -108,9 +123,9 @@ DEPENDENCIES
   mixlib-install (>= 3.17.0)
   mixlib-versioning (>= 1.1.0)
   pry-byebug
+  puma
   rack-test
   rake
-  rb-readline
   redis
   rest-client
   rspec
@@ -118,12 +133,13 @@ DEPENDENCIES
   rspec-legacy_formatters
   rspec-rerun (>= 1.1.0)
   rspec_junit_formatter
-  sinatra (>= 1.4, < 2)
+  sinatra
   sinatra-contrib
   sinatra-cors
   sinatra-param
-  unicorn
+  statsd-ruby
+  trashed
   yajl-ruby
 
 BUNDLED WITH
-   2.3.27
+   2.6.9

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,81 +1,93 @@
 GIT
-  remote: https://github.com/chef/mixlib-install
-  revision: da50e201710530b9ccd5204a65779ad3a64116d3
-  branch: package-manager
+  remote: https://github.com/chef/mixlib-install.git
+  revision: 7d1f8c4e293844e94c39e43734d70414aa6c3b30
+  branch: pm-optional
   specs:
-    mixlib-install (3.15.0)
+    mixlib-install (3.16.3)
       mixlib-shellout
       mixlib-versioning
+      ostruct
       thor
 
 GEM
   remote: https://rubygems.org/
   specs:
-    backports (3.20.2)
-    byebug (11.1.3)
-    chef-utils (18.9.4)
+    backports (3.25.3)
+    byebug (13.0.0)
+      reline (>= 0.6.0)
+    chef-utils (19.2.110)
       concurrent-ruby
     coderay (1.1.3)
-    colorize (0.8.1)
+    colorize (1.1.0)
     concurrent-ruby (1.3.6)
-    diff-lcs (1.4.4)
-    domain_name (0.5.20190701)
-      unf (>= 0.0.5, < 1.0.0)
+    connection_pool (3.0.2)
+    diff-lcs (1.6.2)
+    domain_name (0.6.20240107)
     http-accept (1.7.0)
-    http-cookie (1.0.3)
+    http-cookie (1.1.6)
       domain_name (~> 0.5)
-    json (2.6.1)
-    kgio (2.11.3)
-    method_source (1.0.0)
-    mime-types (3.3.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2021.0212)
-    mixlib-shellout (3.3.9)
+    io-console (0.8.2)
+    json (2.19.5)
+    kgio (2.11.4)
+    logger (1.7.0)
+    method_source (1.1.0)
+    mime-types (3.7.0)
+      logger
+      mime-types-data (~> 3.2025, >= 3.2025.0507)
+    mime-types-data (3.2026.0414)
+    mixlib-shellout (3.4.10)
       chef-utils
-    mixlib-versioning (1.1.0)
-    multi_json (1.15.0)
+    mixlib-versioning (1.2.12)
+    multi_json (1.21.1)
     netrc (0.11.0)
-    pry (0.13.1)
+    ostruct (0.6.3)
+    pry (0.16.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.9.0)
-      byebug (~> 11.0)
-      pry (~> 0.13.0)
+      reline (>= 0.6.0)
+    pry-byebug (3.12.0)
+      byebug (~> 13.0)
+      pry (>= 0.13, < 0.17)
     rack (1.6.13)
     rack-protection (1.5.5)
       rack
-    rack-test (1.1.0)
-      rack (>= 1.0, < 3)
-    raindrops (0.19.1)
-    rake (13.0.6)
+    rack-test (2.2.0)
+      rack (>= 1.3)
+    raindrops (0.20.1)
+    rake (13.4.2)
     rb-readline (0.5.5)
-    redis (4.4.0)
+    redis (5.4.1)
+      redis-client (>= 0.22.0)
+    redis-client (0.29.0)
+      connection_pool
+    reline (0.6.3)
+      io-console (~> 0.5)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rspec (3.10.0)
-      rspec-core (~> 3.10.0)
-      rspec-expectations (~> 3.10.0)
-      rspec-mocks (~> 3.10.0)
-    rspec-core (3.10.1)
-      rspec-support (~> 3.10.0)
-    rspec-expectations (3.10.1)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
-    rspec-its (1.3.0)
-      rspec-core (>= 3.0.0)
-      rspec-expectations (>= 3.0.0)
+      rspec-support (~> 3.13.0)
+    rspec-its (2.0.0)
+      rspec-core (>= 3.13.0)
+      rspec-expectations (>= 3.13.0)
     rspec-legacy_formatters (1.0.2)
       rspec (~> 3.0)
-    rspec-mocks (3.10.2)
+    rspec-mocks (3.13.8)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
+      rspec-support (~> 3.13.0)
     rspec-rerun (1.1.0)
       rspec (~> 3.0)
-    rspec-support (3.10.3)
-    rspec_junit_formatter (0.5.1)
+    rspec-support (3.13.7)
+    rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
     sinatra (1.4.8)
       rack (~> 1.5)
@@ -93,16 +105,13 @@ GEM
       sinatra (>= 1.3)
     statsd-ruby (1.5.0)
     thor (1.5.0)
-    tilt (2.0.10)
-    trashed (3.2.7)
+    tilt (2.7.0)
+    trashed (3.2.8)
       statsd-ruby (~> 1.1)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.7.7)
-    unicorn (6.0.0)
+    unicorn (6.1.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
-    yajl-ruby (1.4.1)
+    yajl-ruby (1.4.3)
 
 PLATFORMS
   ruby
@@ -110,8 +119,8 @@ PLATFORMS
 DEPENDENCIES
   colorize
   json
-  mixlib-install (>= 3.14.0)!
-  mixlib-versioning (~> 1.1.0)
+  mixlib-install (>= 3.16.0)!
+  mixlib-versioning (>= 1.1.0)
   pry-byebug
   rack-test
   rake
@@ -121,9 +130,9 @@ DEPENDENCIES
   rspec
   rspec-its
   rspec-legacy_formatters
-  rspec-rerun (~> 1.1.0)
+  rspec-rerun (>= 1.1.0)
   rspec_junit_formatter
-  sinatra (~> 1.4, < 2)
+  sinatra (>= 1.4, < 2)
   sinatra-contrib
   sinatra-cors
   sinatra-param
@@ -132,4 +141,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   2.3.26
+   2.7.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,33 +1,20 @@
-GIT
-  remote: https://github.com/chef/mixlib-install.git
-  revision: 7d1f8c4e293844e94c39e43734d70414aa6c3b30
-  branch: pm-optional
-  specs:
-    mixlib-install (3.16.3)
-      mixlib-shellout
-      mixlib-versioning
-      ostruct
-      thor
-
 GEM
   remote: https://rubygems.org/
   specs:
     backports (3.25.3)
-    byebug (13.0.0)
-      reline (>= 0.6.0)
-    chef-utils (19.2.110)
+    byebug (12.0.0)
+    chef-utils (19.3.15)
       concurrent-ruby
     coderay (1.1.3)
     colorize (1.1.0)
     concurrent-ruby (1.3.6)
-    connection_pool (3.0.2)
+    connection_pool (2.5.5)
     diff-lcs (1.6.2)
     domain_name (0.6.20240107)
     http-accept (1.7.0)
     http-cookie (1.1.6)
       domain_name (~> 0.5)
-    io-console (0.8.2)
-    json (2.19.5)
+    json (2.19.7)
     kgio (2.11.4)
     logger (1.7.0)
     method_source (1.1.0)
@@ -35,19 +22,23 @@ GEM
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
     mime-types-data (3.2026.0414)
+    mixlib-install (3.17.0)
+      mixlib-shellout
+      mixlib-versioning
+      ostruct
+      thor
     mixlib-shellout (3.4.10)
       chef-utils
     mixlib-versioning (1.2.12)
-    multi_json (1.21.1)
+    multi_json (1.19.1)
     netrc (0.11.0)
     ostruct (0.6.3)
-    pry (0.16.0)
+    pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-      reline (>= 0.6.0)
-    pry-byebug (3.12.0)
-      byebug (~> 13.0)
-      pry (>= 0.13, < 0.17)
+    pry-byebug (3.11.0)
+      byebug (~> 12.0)
+      pry (>= 0.13, < 0.16)
     rack (1.6.13)
     rack-protection (1.5.5)
       rack
@@ -60,8 +51,6 @@ GEM
       redis-client (>= 0.22.0)
     redis-client (0.29.0)
       connection_pool
-    reline (0.6.3)
-      io-console (~> 0.5)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
@@ -103,11 +92,8 @@ GEM
     sinatra-cors (1.2.0)
     sinatra-param (1.6.0)
       sinatra (>= 1.3)
-    statsd-ruby (1.5.0)
     thor (1.5.0)
     tilt (2.7.0)
-    trashed (3.2.8)
-      statsd-ruby (~> 1.1)
     unicorn (6.1.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
@@ -119,7 +105,7 @@ PLATFORMS
 DEPENDENCIES
   colorize
   json
-  mixlib-install (>= 3.16.0)!
+  mixlib-install (>= 3.17.0)
   mixlib-versioning (>= 1.1.0)
   pry-byebug
   rack-test
@@ -136,9 +122,8 @@ DEPENDENCIES
   sinatra-contrib
   sinatra-cors
   sinatra-param
-  trashed
   unicorn
   yajl-ruby
 
 BUNDLED WITH
-   2.7.2
+   2.3.27

--- a/app.rb
+++ b/app.rb
@@ -667,6 +667,8 @@ class Omnitruck < Sinatra::Base
   #
   def prepare_install_sh
     context = { base_url: url(settings.virtual_path).chomp('/') }
+    # Allow base_url override from query parameter
+    context[:base_url] = params['base_url'] if params['base_url']
     context[:license_id] = params['license_id'] if params['license_id']
     Mixlib::Install.install_sh(context)
   end
@@ -679,6 +681,8 @@ class Omnitruck < Sinatra::Base
   #
   def prepare_install_ps1
     context = { base_url: url(settings.virtual_path).chomp('/') }
+    # Allow base_url override from query parameter
+    context[:base_url] = params['base_url'] if params['base_url']
     context[:license_id] = params['license_id'] if params['license_id']
     Mixlib::Install.install_ps1(context)
   end

--- a/app.rb
+++ b/app.rb
@@ -172,6 +172,7 @@ class Omnitruck < Sinatra::Base
   get /install\.(?<extension>[\w]+)/ do
     param :extension, String, required: true
     param :license_id, String
+    param :base_url, String
 
     case params['extension']
     when 'sh'

--- a/app.rb
+++ b/app.rb
@@ -171,6 +171,7 @@ class Omnitruck < Sinatra::Base
   #
   get /install\.(?<extension>[\w]+)/ do
     param :extension, String, required: true
+    param :license_id, String
 
     case params['extension']
     when 'sh'
@@ -665,7 +666,9 @@ class Omnitruck < Sinatra::Base
   #   Contents of the install.sh script
   #
   def prepare_install_sh
-    Mixlib::Install.install_sh(base_url: url(settings.virtual_path).chomp('/'))
+    context = { base_url: url(settings.virtual_path).chomp('/') }
+    context[:license_id] = params['license_id'] if params['license_id']
+    Mixlib::Install.install_sh(context)
   end
 
   #
@@ -675,6 +678,8 @@ class Omnitruck < Sinatra::Base
   #   Contents of the install.ps1 script
   #
   def prepare_install_ps1
-    Mixlib::Install.install_ps1(base_url: url(settings.virtual_path).chomp('/'))
+    context = { base_url: url(settings.virtual_path).chomp('/') }
+    context[:license_id] = params['license_id'] if params['license_id']
+    Mixlib::Install.install_ps1(context)
   end
 end

--- a/app.rb
+++ b/app.rb
@@ -56,6 +56,9 @@ class Omnitruck < Sinatra::Base
     set :allow_methods, "GET"
     set :allow_headers, "content-type,if-modified-since"
 
+    # Allow all hosts - omnitruck is a public API; empty list = no restrictions
+    set :host_authorization, permitted_hosts: []
+
     set :raise_errors, false
     set :show_exceptions, false
 
@@ -151,7 +154,7 @@ class Omnitruck < Sinatra::Base
     [status, headers, body]
   end
 
-  get /(?<channel>\/[\w]+)?\/(?<project>[\w-]+)\/versions\/?$/ do
+  get /(?<channel>\/[\w]+)?\/(?<project>[\w-]+)\/versions\/?/ do
     pass unless project_allowed(project)
     redirect_url = "/#{channel}/#{project}/packages"
     redirect_url += "?v=#{params['v']}" unless params['v'].nil?
@@ -169,7 +172,7 @@ class Omnitruck < Sinatra::Base
   #
   # Serve up the installer script
   #
-  get /install\.(?<extension>[\w]+)/ do
+  get /\/install\.(?<extension>[\w]+)/ do
     param :extension, String, required: true
     param :license_id, String
     param :base_url, String
@@ -213,7 +216,7 @@ class Omnitruck < Sinatra::Base
   # Endpoints
   #########################################################################
 
-  get /(?<channel>\/[\w]+)?\/(?<project>[\w-]+)\/download\/?$/ do
+  get /(?<channel>\/[\w]+)?\/(?<project>[\w-]+)\/download\/?/ do
     param :channel, String, default: 'stable'
     param :project, String, in: Chef::Cache::KNOWN_PROJECTS, required: true
     param :p,       String, required: true
@@ -265,8 +268,8 @@ class Omnitruck < Sinatra::Base
     redirect original_url
   end
 
-  # another dirty hack to handle amazon 2, and how the commercial downloads api handles / uses the metadata. All this needs to be rewritten to include amazon2 as a valid platform. 
-  get /(?<channel>\/[\w]+)?\/(?<project>[\w-]+)\/metadata\/?$/ do
+  # another dirty hack to handle amazon 2, and how the commercial downloads api handles / uses the metadata. All this needs to be rewritten to include amazon2 as a valid platform.
+  get /(?<channel>\/[\w]+)?\/(?<project>[\w-]+)\/metadata\/?/ do
     # Legacy params which affect the default channel
     param :prerelease, Boolean
     param :nightlies,  Boolean
@@ -281,16 +284,16 @@ class Omnitruck < Sinatra::Base
     param :p,       String, required: true
     param :pv,      String, required: true
     param :m,       String, required: true
-    
+
     # Get package information
     package_info = get_package_info
     # Original URL from package info
     original_url = package_info["url"]
-    
+
     # Debug the important variables
     settings.logging.info("Metadata request: Project=#{params['project']}, Platform=#{params['p']}, Version=#{params['pv']}")
     settings.logging.debug("Original URL: #{original_url}")
-    
+
     # Special case handling for Amazon Linux 2
     if params['p'] == "amazon" && params['pv'] == "2"
       # For chef-workstation on Amazon Linux 2, use EL7 packages (highest priority)
@@ -319,7 +322,7 @@ class Omnitruck < Sinatra::Base
         settings.logging.info("DEBUG - Amazon 2023 URL rewritten to: #{package_info["url"]}")
       end
     end
-    
+
     # Respond with the updated package stuff
     if request.accept? 'text/plain'
       parse_plain_text(package_info)
@@ -329,7 +332,7 @@ class Omnitruck < Sinatra::Base
     end
   end
 
-  get /(?<channel>\/[\w]+)?\/(?<project>[\w-]+)\/packages\/?$/ do
+  get /(?<channel>\/[\w]+)?\/(?<project>[\w-]+)\/packages\/?/ do
     param :channel, String, default: 'stable'
     param :project, String, in: Chef::Cache::KNOWN_PROJECTS, required: true
     param :flatten, Boolean
@@ -359,7 +362,7 @@ class Omnitruck < Sinatra::Base
     JSON.pretty_generate(available_versions.last)
   end
 
-  get /architectures/ do
+  get /\/architectures/ do
     content_type :json
 
     JSON.pretty_generate(
@@ -367,7 +370,7 @@ class Omnitruck < Sinatra::Base
     )
   end
 
-  get /platforms/ do
+  get /\/platforms/ do
     content_type :json
 
     JSON.pretty_generate({
@@ -535,7 +538,7 @@ class Omnitruck < Sinatra::Base
         # For other products like chef-server-core, use version threshold
         product_version_threshold = Opscode::Version.parse("15.10.12")
         settings.logging.info("Non-client product requested: #{current_project}, version: #{opscode_version}")
-        
+
         if opscode_version >= product_version_threshold
           settings.logging.info("Requested version is >= 15.10.12. Keeping platform as Amazon with version 2.")
           current_platform = "amazon"

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,5 @@
+port ENV.fetch("PORT", 8080)
+workers ENV.fetch("WEB_CONCURRENCY", 2)
+threads_count = ENV.fetch("PUMA_MAX_THREADS", 5)
+threads threads_count, threads_count
+preload_app!

--- a/dev/Dockerfile.omnitruck
+++ b/dev/Dockerfile.omnitruck
@@ -33,5 +33,5 @@ ENTRYPOINT ["/entrypoint.sh"]
 # Expose the development port
 EXPOSE 9393
 
-# Use unicorn instead of shotgun since it's already installed
-CMD ["bundle", "exec", "puma", "-l", "0.0.0.0:9393"]
+# Run Puma with config.ru from the app directory
+CMD ["bundle", "exec", "puma", "-C", "config/puma.rb", "-b", "tcp://0.0.0.0:9393", "config.ru"]

--- a/dev/Dockerfile.omnitruck
+++ b/dev/Dockerfile.omnitruck
@@ -1,4 +1,4 @@
-FROM ruby:3.1.6-alpine
+FROM ruby:3.4.9-alpine
 
 ENV APP_ROOT=/app
 ENV RACK_ENV=development
@@ -21,7 +21,7 @@ RUN apk add --no-cache --update \
     bash
 
 # Install bundler with specific version for consistency
-RUN gem install bundler -v '2.3.26' --no-document
+RUN gem install bundler -v '2.6.9' --no-document
 
 # Copy the entrypoint script
 COPY entrypoint.sh /entrypoint.sh
@@ -34,4 +34,4 @@ ENTRYPOINT ["/entrypoint.sh"]
 EXPOSE 9393
 
 # Use unicorn instead of shotgun since it's already installed
-CMD ["bundle", "exec", "unicorn", "-l", "0.0.0.0:9393"]
+CMD ["bundle", "exec", "puma", "-l", "0.0.0.0:9393"]

--- a/dev/Dockerfile.redis
+++ b/dev/Dockerfile.redis
@@ -1,4 +1,4 @@
-FROM redis:7.4.0-alpine3.20
+FROM redis:7.4.9-alpine
 
 # Add custom Redis configuration if needed
 COPY redis.conf /usr/local/etc/redis/redis.conf

--- a/lib/chef/version.rb
+++ b/lib/chef/version.rb
@@ -25,9 +25,7 @@ require 'forwardable'
 
 module Opscode
   class Version
-    SUPPORTED_FORMATS = Mixlib::Versioning::DEFAULT_FORMATS + [
-      Opscode::Version::Incomplete
-    ]
+    SUPPORTED_FORMATS = [Opscode::Version::Incomplete] + Mixlib::Versioning::DEFAULT_FORMATS
     extend Forwardable
 
     include Comparable

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -1,1380 +1,548 @@
-# #--
-# # Author:: Tyler Cloke (tyler@opscode.com)
-# # Author:: Stephen Delano (stephen@opscode.com)
-# # Author:: Seth Chisamore (sethc@opscode.com)
-# # Author:: Lamont Granquist (lamont@opscode.com)
-# # Copyright:: Copyright (c) 2010-2013 Chef Software, Inc.
-# # License:: Apache License, Version 2.0
-# #
-# # Licensed under the Apache License, Version 2.0 (the "License");
-# # you may not use this file except in compliance with the License.
-# # You may obtain a copy of the License at
-# #
-# #     http://www.apache.org/licenses/LICENSE-2.0
-# #
-# # Unless required by applicable law or agreed to in writing, software
-# # distributed under the License is distributed on an "AS IS" BASIS,
-# # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# # See the License for the specific language governing permissions and
-# # limitations under the License.
-# #
-
-# require 'spec_helper'
-# require 'uri'
-
-# context 'Omnitruck' do
-#   def app
-#     Omnitruck
-#   end
-
-#   context "/products endpoint" do
-#     it "returns all the products" do
-#       get("/products")
-
-#       response = JSON.parse(last_response.body)
-#       Chef::Cache::KNOWN_PROJECTS.each do |project|
-#         response.include?(project)
-#       end
-#     end
-#   end
-
-#   context "/platforms endpoint" do
-#     it "returns JSON data" do
-#       get("/platforms")
-#       expect(last_response.header['Content-Type']).to include 'application/json'
-#     end
-#   end
-
-#   context "/architectures endpoint" do
-#     it "returns all the architectures" do
-#       get("/architectures")
-
-#       response = JSON.parse(last_response.body)
-#       Mixlib::Install::Options::SUPPORTED_ARCHITECTURES.each do |arch|
-#         response.include?(arch)
-#       end
-#     end
-#   end
-
-#   context "download / metadata endpoints" do
-#     let(:channel) { nil }
-#     let(:project){ nil }
-#     let(:project_version){ nil }
-#     let(:platform) { nil }
-#     let(:platform_version) { nil }
-#     let(:architecture) { nil }
-#     let(:params) do
-#       params = {}
-#       params[:v] = project_version if project_version
-#       params[:p] = platform if platform
-#       params[:pv] = platform_version if platform_version
-#       params[:m] = architecture if architecture
-#       params
-#     end
-
-#     let(:expected_project) { project }
-#     let(:expected_channel) { channel }
-#     let(:expected_platform) { platform }
-#     let(:expected_platform_version) { platform_version }
-#     let(:expected_architecture) { architecture }
-#     let(:expected_version) { project_version }
-#     let(:expected_info) do
-#       record = spec_data_record(expected_channel, expected_project, expected_platform, expected_platform_version, expected_architecture, expected_version)
-
-#       {
-#         url: record['url'],
-#         sha256: record['sha256'],
-#         sha1: record['sha1'],
-#         version: expected_version,
-#       }
-#     end
-
-#     let(:endpoint) { nil }
-
-#     # shared_examples_for 'a correct package info' do
-#     #   context 'download' do
-#     #     let(:endpoint) { "/#{channel}/#{project}/download" }
-
-#     #     it "should serve a redirect package " do
-#     #       get(endpoint, params)
-#     #       puts "Params passed to download: #{params}"
-#     #       puts "Expected Info: #{expected_info}"
-#     #       expect(last_response).to be_redirect
-#     #       follow_redirect!
-#     #       puts "Redirected to URL: #{last_request.url}"
-#     #       expect(last_request.url).to eq(expected_info[:url])
-#     #     end
-#     #   end
-
-#       ## the problem we have here is that the latest version of the prdocuts, do not include old platforms. so the tests are faling. 
-#       ## todo ##
-#       ## we need to update these tests to account for the latest product version, as well as test old prodcut versions that map to the right platform. IE:
-#       ##        expected: "https://packages.chef.io/files/stable/chef/17.10.3/el/6/chef-17.10.3-1.el6.x86_64.rpm"
-#       ##        got: "https://packages.chef.io/files/stable/chef/18.3.0/el/6/chef-18.3.0-1.el6.x86_64.rpm"
-#       ## this will fail because el/6 does not have a chef 18.3.0 valid installer.... recomend moving the tests to something like: context 'legacy metadata' 
-#       # context 'metadata' do
-#       #   let(:endpoint) { "/#{channel}/#{project}/metadata" }
-
-#       #   it "should serve JSON metadata for package" do
-#       #     get(endpoint, params, "HTTP_ACCEPT" => "application/json")
-#       #     metadata_json = last_response.body
-#       #     parsed_json = JSON.parse(metadata_json)
-#       #     puts "Params passed to metadata: #{params}"
-#       #     puts "Expected JSON Metadata: #{expected_info}"
-#       #     puts "Received JSON Metadata: #{parsed_json}"
-#       #     expect(parsed_json['version']).to eq(expected_info[:version])
-#       #     expect(parsed_json['url']).to eq(expected_info[:url])
-#       #     expect(parsed_json['sha256']).to eq(expected_info[:sha256])
-#       #     expect(parsed_json['sha1']).to eq(expected_info[:sha1])
-#       #   end
-
-#         it "should serve plain text metadata for package" do
-#           get(endpoint, params, "HTTP_ACCEPT" => "text/plain")
-#           text_metadata = last_response.body
-#           parsed_metadata = text_metadata.lines.inject({}) do |metadata, line|
-#             key, value = line.strip.split("\t")
-#             metadata[key] = value
-#             metadata
-#           end
-
-#           expect(parsed_metadata['version']).to eq(expected_info[:version])
-#           expect(parsed_metadata['url']).to eq(expected_info[:url])
-#           expect(parsed_metadata['sha256']).to eq(expected_info[:sha256])
-#           expect(parsed_metadata['sha1']).to eq(expected_info[:sha1])
-#         end
-#       end
-
-#       context "an incorrect version" do
-#         let(:endpoint) { "/#{channel}/#{project}/download" }
-
-#         context "download" do
-#           it "should 404" do
-#             params['v'] = '0.0.0'
-#             get(endpoint, params)
-#             expect(last_response).to be_not_found
-#           end
-#         end
-
-#         context "metadata" do
-#           let(:endpoint) { "/#{channel}/#{project}/metadata" }
-#           it "should 404" do
-#             params['v'] = '0.0.0'
-#             get(endpoint, params)
-#             expect(last_response).to be_not_found
-#           end
-#         end
-#       end
-
-#       context "an incorrect platform" do
-#         let(:endpoint) { "/#{channel}/#{project}/download" }
-
-#         context "download" do
-#           it "should 404" do
-#             params['p'] = 'foo'
-#             get(endpoint, params)
-#             expect(last_response).to be_not_found
-#           end
-#         end
-
-#         context "metadata" do
-#           let(:endpoint) { "/#{channel}/#{project}/metadata" }
-#           it "should 404" do
-#             params['p'] = 'foo'
-#             get(endpoint, params)
-#             expect(last_response).to be_not_found
-#           end
-#         end
-#       end
-#     end
-
-#     context 'automate and delivery' do
-#       let(:channel) { 'stable' }
-#       let(:platform) { 'el' }
-#       let(:platform_version) { '6' }
-#       let(:architecture) { 'x86_64' }
-
-#       shared_examples_for 'automate and delivery compatibility' do
-#         let(:expected_project) { 'automate' }
-
-#         context 'without a version' do
-#           let(:project_version) { nil }
-#           let(:expected_version) { '1.8.96' }
-
-#           it_behaves_like 'a correct package info'
-#         end
-
-#         context 'latest version' do
-#           let(:project_version) { 'latest' }
-#           let(:expected_version) { '1.8.96' }
-
-#           it_behaves_like 'a correct package info'
-#         end
-
-#         context 'automate version' do
-#           let(:project_version) { '0.7.61' }
-
-#           it_behaves_like 'a correct package info'
-#         end
-
-#         context 'delivery version' do
-#           let(:project_version) { '0.4.199' }
-#           let(:expected_project) { 'delivery' }
-
-#           it_behaves_like 'a correct package info'
-#         end
-#       end
-
-#       %w(automate delivery).each do |proj|
-#         context "for #{proj}" do
-#           let(:project) { proj }
-
-#           it_behaves_like 'automate and delivery compatibility'
-#         end
-#       end
-#     end
-
-#     context "for chef" do
-#       let(:project) { "chef" }
-
-#       context 'for stable' do
-#         let(:channel) { 'stable' }
-
-#         context 'for amazon linux' do
-#           let(:platform) { 'amazon' }
-
-#           context 'for 2018.03' do
-#             let(:expected_platform) { 'el' }
-#             let(:platform_version) { '2018.03' }
-#             let(:expected_platform_version) { '6' }
-
-#             context 'for x86_64' do
-#               let(:architecture) { 'x86_64' }
-
-#               context 'without a version' do
-#                 let(:project_version) { nil }
-#                 let(:expected_version) { latest_stable_chef }
-
-#                 it_behaves_like 'a correct package info'
-#               end
-#             end
-#           end
-
-#           context 'for 2' do
-#             let(:expected_platform) { 'el' }
-#             let(:platform_version) { '2' }
-#             let(:expected_platform_version) { '7' }
-
-#             context 'for x86_64' do
-#               let(:architecture) { 'x86_64' }
-
-#               context 'without a version' do
-#                 let(:project_version) { nil }
-#                 let(:expected_version) { latest_stable_chef }
-
-#                 it_behaves_like 'a correct package info'
-#               end
-#             end
-#           end
-
-#           context 'for 2022' do
-#             # Even though this block is for stable, the only place we have an amazon linux 2022 build is current
-#             let(:channel) { 'current' }
-#             let(:platform_version) { '2022' }
-
-#             context 'for x86_64' do
-#               let(:architecture) { 'x86_64' }
-
-#               context 'without a version' do
-#                 let(:project_version) { nil }
-#                 let(:expected_version) { latest_current_chef }
-
-#                 it_behaves_like 'a correct package info'
-#               end
-#             end
-#           end
-#         end
-
-#         context 'for mac_os_x' do
-#           let(:platform) { 'mac_os_x' }
-
-#           context 'for 10.7' do
-#             let(:platform_version) { '10.7' }
-
-#             context 'for x86_64' do
-#               let(:architecture) { 'x86_64' }
-
-#               context 'without a version' do
-#                 let(:project_version) { nil }
-#                 let(:expected_version) { '12.2.1' }
-
-#                 it_behaves_like 'a correct package info'
-#               end
-#             end
-#           end
-
-#           # YOLO mode
-#           context 'for 10.12' do
-#             let(:platform_version) { '10.12' }
-
-#             context 'for x86_64' do
-#               let(:architecture) { 'x86_64' }
-
-#               context 'without a version' do
-#                 let(:project_version) { nil }
-#                 let(:expected_version) { '15.2.20' }
-
-#                 it_behaves_like 'a correct package info'
-#               end
-#             end
-#           end
-
-#           context 'for 11' do
-#             let(:platform_version) { '11' }
-
-#             context 'for x86_64' do
-#               let(:architecture) { 'x86_64' }
-
-#               context 'without a version' do
-#                 let(:project_version) { nil }
-#                 let(:expected_version) { latest_stable_chef }
-
-#                 it_behaves_like 'a correct package info'
-#               end
-#             end
-
-#             context 'for arm64' do
-#               let(:architecture) { 'arm64' }
-
-#               # Temporary test(s) to handle our split world where we may not have a native build
-#               context 'without native build' do
-#                 let(:expected_architecture) { 'x86_64' }
-
-#                 context 'with a version' do
-#                   let(:project_version) { "15.17.4" }
-#                   let(:expected_platform_version) { '10.15' }
-
-#                   it_behaves_like 'a correct package info'
-#                 end
-#               end
-
-#               context 'with native build' do
-#                 let(:expected_platform_version) { '11' }
-#                 let(:expected_architecture) { 'aarch64' }
-
-#                 context 'with a version' do
-#                   let(:project_version) { '17.10.3' }
-
-#                   it_behaves_like 'a correct package info'
-#                 end
-#               end
-#             end
-#           end
-
-#           context 'with mix of 11.x and 11' do
-#             let(:architecture) { 'x86_64' }
-#             let(:project_version) { "17.8.25" }
-
-#             context 'with 10.x' do
-#               let(:platform_version) { '10.15' }
-
-#               it_behaves_like 'a correct package info'
-#             end
-
-#             # version fallback comparison
-#             context 'with 11.0' do
-#               let(:platform_version) { '11.0' }
-#               let(:expected_platform_version) { '11' }
-
-#               it_behaves_like 'a correct package info'
-#             end
-
-#             # version fallback comparison / yolo mode
-#             context 'with 11.10' do
-#               let(:platform_version) { '11.10' }
-#               let(:expected_platform_version) { '11' }
-
-#               it_behaves_like 'a correct package info'
-#             end
-
-#             context 'with 11' do
-#               let(:platform_version) { '11' }
-
-#               it_behaves_like 'a correct package info'
-#             end
-#           end
-#         end
-
-#         # SLES 11 covers use cases in their entirety.
-#         # Edge cases and basic platform and project version differences
-#         # are covered as one-off tests.
-#         context 'for sles' do
-#           let(:platform) { 'sles' }
-
-#           shared_examples_for 'sles artifacts' do
-#             let(:expected_platform) { 'sles' }
-
-#             context 'for 11' do
-#               let(:platform_version) { '11' }
-
-#               context 'for i686' do
-#                 let(:architecture) { 'i686' }
-#                 let(:expected_platform) { 'el' }
-#                 let(:expected_platform_version) { '5' }
-#                 let(:expected_architecture) { 'i386' }
-
-#                 context 'with a version' do
-#                   let(:project_version) { '12.0.3' }
-
-#                   it_behaves_like 'a correct package info'
-#                 end
-#               end
-
-#               context 'for s390x' do
-#                 let(:architecture) { 's390x' }
-
-#                 context 'without a version' do
-#                   let(:project_version) { nil }
-#                   let(:expected_version) { '15.1.36' }
-
-#                   it_behaves_like 'a correct package info'
-#                 end
-
-#                 context 'with pre-native sles build version (no remapping)' do
-#                   let(:project_version) { '12.20.3' }
-
-#                   it_behaves_like 'a correct package info'
-#                 end
-#               end
-
-#               context 'for x86_64' do
-#                 let(:architecture) { 'x86_64' }
-
-#                 context 'without a version' do
-#                   let(:project_version) { nil }
-#                   let(:expected_version) { '15.1.36' }
-
-#                   it_behaves_like 'a correct package info'
-#                 end
-
-#                 context 'with latest version' do
-#                   let(:project_version) { 'latest' }
-#                   let(:expected_version) { '15.1.36' }
-
-#                   it_behaves_like 'a correct package info'
-#                 end
-
-#                 context 'with first native sles build version' do
-#                   let(:project_version) { '12.21.1' }
-
-#                   it_behaves_like 'a correct package info'
-#                 end
-
-#                 context 'with non-native sles build version' do
-#                   let(:project_version) { '12.20.3' }
-#                   let(:expected_platform) { 'el' }
-#                   let(:expected_platform_version) { '5' }
-
-#                   it_behaves_like 'a correct package info'
-#                 end
-
-#                 context 'for a latest non-native sles project (manage)' do
-#                   let(:project) { 'manage' }
-#                   let(:project_version) { nil }
-#                   let(:expected_platform) { 'el' }
-#                   let(:expected_platform_version) { '5' }
-#                   let(:expected_version) { '2.5.8' }
-
-#                   it_behaves_like 'a correct package info'
-#                 end
-#               end
-#             end
-
-#             context 'for 12' do
-#               let(:platform_version) { '12' }
-
-#               context 'for x86_64' do
-#                 let(:architecture) { 'x86_64'}
-
-#                 context 'with first native sles build version' do
-#                   let(:project_version) { '12.21.1' }
-
-#                   it_behaves_like 'a correct package info'
-#                 end
-
-#                 context 'with partial 12 project_version' do
-#                   let(:project_version) { '12' }
-#                   let(:expected_version) { '12.22.5' }
-
-#                   it_behaves_like 'a correct package info'
-#                 end
-
-#                 context 'with partial 12.21 project_version' do
-#                   let(:project_version) { '12.21' }
-#                   let(:expected_version) { '12.21.31' }
-
-#                   it_behaves_like 'a correct package info'
-#                 end
-
-#                 context 'with non-native sles build version partial version 12.20' do
-#                   let(:project_version) { '12.20' }
-#                   let(:expected_version) { '12.20.3' }
-#                   let(:expected_platform) { 'el' }
-#                   let(:expected_platform_version) { '6' }
-#                   let(:expected_architecture) { 'x86_64' }
-
-#                   it_behaves_like 'a correct package info'
-#                 end
-
-#                 context 'with partial 13 project_version' do
-#                   let(:project_version) { '13' }
-#                   let(:expected_version) { '13.12.14' }
-
-#                   it_behaves_like 'a correct package info'
-#                 end
-
-#                 context 'with partial 13.1 project_version' do
-#                   let(:project_version) { '13.1' }
-#                   let(:expected_version) { '13.1.31' }
-
-#                   it_behaves_like 'a correct package info'
-#                 end
-
-#                 context 'with 13.1.31 project_version' do
-#                   let(:project_version) { '13.1.31' }
-
-#                   it_behaves_like 'a correct package info'
-#                 end
-
-#                 context 'with non-native sles build version' do
-#                   let(:project_version) { '12.20.3' }
-#                   let(:expected_platform) { 'el' }
-#                   let(:expected_platform_version) { '6' }
-
-#                   it_behaves_like 'a correct package info'
-#                 end
-
-#                 context 'for automate' do
-#                   let(:project) { 'automate' }
-
-#                   context 'with first native sles build version' do
-#                     let(:project_version) { '0.8.5' }
-
-#                     it_behaves_like 'a correct package info'
-#                   end
-
-#                   context 'with non-native sles build version' do
-#                     let(:project_version) { '0.7.61' }
-#                     let(:expected_platform) { 'el' }
-#                     let(:expected_platform_version) { '6' }
-
-#                     it_behaves_like 'a correct package info'
-#                   end
-#                 end
-
-#                 context 'for chef-server' do
-#                   let(:project) { 'chef-server' }
-
-#                   context 'with first native sles build version' do
-#                     let(:project_version) { '12.15.0' }
-
-#                     it_behaves_like 'a correct package info'
-#                   end
-
-#                   context 'with non-native sles build version' do
-#                     let(:project_version) { '12.13.0' }
-#                     let(:expected_platform) { 'el' }
-#                     let(:expected_platform_version) { '6' }
-
-#                     it_behaves_like 'a correct package info'
-#                   end
-#                 end
-
-#                 context 'for chefdk' do
-#                   let(:project) { 'chefdk' }
-
-#                   context 'with first native sles build version' do
-#                     let(:project_version) { '1.3.43' }
-
-#                     it_behaves_like 'a correct package info'
-#                   end
-
-#                   context 'with non-native sles build version' do
-#                     let(:project_version) { '1.3.40' }
-#                     let(:expected_platform) { 'el' }
-#                     let(:expected_platform_version) { '6' }
-
-#                     it_behaves_like 'a correct package info'
-#                   end
-#                 end
-
-#                 context 'for inspec' do
-#                   let(:project) { 'inspec' }
-
-#                   context 'with first native sles build version' do
-#                     let(:project_version) { '1.20.0' }
-
-#                     it_behaves_like 'a correct package info'
-#                   end
-
-#                   context 'with non-native sles build version' do
-#                     let(:project_version) { '1.19.2' }
-#                     let(:expected_platform) { 'el' }
-#                     let(:expected_platform_version) { '6' }
-
-#                     it_behaves_like 'a correct package info'
-#                   end
-#                 end
-#               end
-#             end
-#           end
-
-#           it_behaves_like 'sles artifacts'
-
-#           context 'when suse' do
-#             let(:platform) { 'suse' }
-
-#             it_behaves_like 'sles artifacts'
-#           end
-
-#           context 'when opensuse-leap' do
-#             let(:platform) { 'opensuse-leap' }
-
-#             it_behaves_like 'sles artifacts'
-#           end
-#         end
-
-#         context 'for ubuntu' do
-#           let(:platform) { 'ubuntu' }
-
-#           context 'for 12.04' do
-#             let(:platform_version) { '12.04' }
-
-#             context 'for i686' do
-#               let(:architecture) { 'x86_64' }
-
-#               context 'without a version' do
-#                 let(:project_version) { nil }
-#                 let(:expected_version) { '13.4.24' }
-
-#                 it_behaves_like 'a correct package info'
-#               end
-
-#               context 'with "latest"' do
-#                 let(:project_version) { 'latest' }
-#                 let(:expected_version) { '13.4.24' }
-
-#                 it_behaves_like 'a correct package info'
-#               end
-
-#               context 'with partial version' do
-#                 let(:project_version) { '12.1' }
-#                 let(:expected_version) { '12.1.2' }
-
-#                 it_behaves_like 'a correct package info'
-#               end
-
-#               context 'with full version' do
-#                 let(:project_version) { '10.24.0' }
-
-#                 it_behaves_like 'a correct package info'
-#               end
-#             end
-#           end
-
-#           # Here we are testing an edge condition of yolo mode.
-#           # Cache has 12.6.1 version for 13.04 but it does not have it for 14.04
-#           # Yolo mode should serve the 13.04 artifact when asked latest on 14.04
-#           context 'for 14.04' do
-#             let(:platform_version) { '14.04' }
-
-#             context 'for x86_64' do
-#               let(:architecture) { 'x86_64' }
-
-#               context 'with "latest"' do
-#                 let(:project_version) { 'latest' }
-#                 let(:expected_version) { '15.1.36' }
-
-#                 it_behaves_like 'a correct package info'
-#               end
-#             end
-#           end
-
-#           # What we're testing on this next one is if yolo is sorting numerically or lexicographically
-#           # If we're getting string compares we'll get "10.04" as our yolo version, but we want to do a
-#           # numeric compare and get 12.04 instead:
-#           #   String (Wrong): "101" < "10" < "12"
-#           #   Integer (Right): 10 < 12 < 101
-#           context 'for extreme yolo version 101.04' do
-#             let(:platform_version) { '101.04' }
-#             let(:expected_platform_version) { '20.04' }
-
-#             context 'for i686' do
-#               let(:architecture) { 'x86_64' }
-
-#               context 'without a version' do
-#                 let(:project_version) { nil }
-#                 let(:expected_version) { latest_stable_chef }
-
-#                 it_behaves_like 'a correct package info'
-#               end
-#             end
-#           end
-#         end
-
-#         context 'for windows' do
-#           let(:platform) { 'windows' }
-#           let(:x86_64_only) { %w{ 8 } }
-
-#           %w{
-#             2019
-#             2016
-#             2012
-#             2012r2
-#             10
-#             8
-#           }.each do |windows_platform_version|
-
-#             context "for #{windows_platform_version}" do
-#               let(:platform_version) { windows_platform_version }
-
-#               %w{
-#                 i386
-#                 i686
-#               }.each do |architecture|
-
-#                 context "for #{architecture}" do
-#                   let(:architecture) { architecture }
-#                   let(:expected_architecture) { 'i386' }
-#                   let(:expected_platform_version) { (windows_platform_version == '2012') ? '2012' : '2012r2' }
-
-#                   context 'with specific version' do
-#                     let(:project_version) { '12.6.0' }
-
-#                     it_behaves_like 'a correct package info'
-#                   end
-
-#                   context 'with only a partial version specification' do
-#                     let(:project_version) { '12.9' }
-#                     let(:expected_version) { '12.9.41' }
-
-#                     it_behaves_like 'a correct package info'
-#                   end
-
-#                   context 'with specific version that has an x86_64 package' do
-#                     let(:project_version) { '12.7.2' }
-
-#                     it_behaves_like 'a correct package info'
-#                   end
-#                 end
-#               end
-
-#               context "for x86_64" do
-#                 let(:architecture) { "x86_64" }
-#                 let(:exepcted_platform_version) { windows_platform_version }
-
-#                 context 'without a version' do
-#                   let(:project_version) { nil }
-#                   let(:expected_version) { latest_stable_chef }
-
-#                   it_behaves_like 'a correct package info'
-#                 end
-
-#                 context 'with specific version that has an x86_64 package' do
-#                   let(:project_version) { '15.12.22' }
-
-#                   it_behaves_like 'a correct package info'
-#                 end
-
-#                 context 'with a version only specifying major' do
-#                   let(:project_version) { "15" }
-#                   let(:expected_version) { '15.17.4' }
-
-#                   it_behaves_like 'a correct package info'
-#                 end
-
-#                 context 'with a version only specifing major and minor' do
-#                   let(:project_version) { "15.12" }
-#                   let(:expected_version) { '15.12.22' }
-
-#                   it_behaves_like 'a correct package info'
-#                 end
-#               end
-#             end
-#           end
-
-#           [nil, "12", "13.10", "15.0.300"].each do |v|
-#             context "for version #{v}" do
-#               let(:project_version) { v }
-
-#               context 'with 32 and 64 bit artifacts' do
-#                 let(:platform_version) { "2008r2" }
-#                 let(:endpoint) { "/#{channel}/#{project}/metadata" }
-
-#                 %w{i386 i686}.each do |arch|
-#                   context "for #{arch}" do
-#                     let(:architecture) { arch }
-
-#                     it 'should return 32 bit artifact' do
-#                       get(endpoint, params, "HTTP_ACCEPT" => "application/json")
-#                       metadata_json = last_response.body
-#                       parsed_json = JSON.parse(metadata_json)
-
-#                       expect(parsed_json['url']).to match(/x86/)
-#                       expect(parsed_json['url']).not_to match(/i686/)
-#                       expect(parsed_json['url']).not_to match(/x86_64/)
-#                     end
-#                   end
-#                 end
-
-#                 context "for x86_64" do
-#                   let(:architecture) { "x86_64" }
-
-#                   it 'should return 64 bit artifact' do
-#                     get(endpoint, params, "HTTP_ACCEPT" => "application/json")
-#                     metadata_json = last_response.body
-#                     parsed_json = JSON.parse(metadata_json)
-
-#                     expect(parsed_json['url']).not_to match(/i386/)
-#                     expect(parsed_json['url']).not_to match(/i686/)
-#                     expect(parsed_json['url']).to match(/x64/)
-#                   end
-#                 end
-#               end
-#             end
-#           end
-#         end
-
-#         context 'for nexus' do
-#           let(:platform) { 'nexus' }
-
-#           context 'for 7.0(3)I2(2)' do
-#             let(:platform_version) { '7.0(3)I2(2)' }
-#             let(:expected_platform_version) { '7' }
-
-#             context 'for x86_64' do
-#               let(:architecture) { 'x86_64' }
-
-#               context 'without a version' do
-#                 let(:project_version) { nil }
-#                 let(:expected_version) { '12.19.33' }
-
-#                 it_behaves_like 'a correct package info'
-#               end
-#             end
-#           end
-#         end
-
-#         context 'for fedora' do
-#           let(:platform) { 'fedora' }
-#           let(:expected_platform) { 'el' }
-
-#           context 'for 14 (Arista!)' do
-#             let(:platform_version) { '14' }
-#             let(:expected_platform_version) { '6' }
-
-#             context 'for x86_64' do
-#               let(:architecture) { 'x86_64' }
-
-#               context 'without a version' do
-#                 let(:project_version) { nil }
-#                 let(:expected_version) { latest_stable_chef }
-
-#                 it_behaves_like 'a correct package info'
-#               end
-#             end
-#           end
-
-#           context 'for 28' do
-#             let(:platform_version) { '28' }
-#             let(:expected_platform_version) { '7' }
-
-#             context 'for x86_64' do
-#               let(:architecture) { 'x86_64' }
-
-#               context 'without a version' do
-#                 let(:project_version) { nil }
-#                 let(:expected_version) { latest_stable_chef }
-
-#                 it_behaves_like 'a correct package info'
-#               end
-#             end
-#           end
-#         end
-
-#         context 'for ios_xr' do
-#           let(:platform) { 'ios_xr' }
-
-#           context 'for 6.0.0.14I' do
-#             let(:platform_version) { '6.0.0.14I' }
-#             let(:expected_platform_version) { '6' }
-
-#             context 'for x86_64' do
-#               let(:architecture) { 'x86_64' }
-
-#               context 'without a version' do
-#                 let(:project_version) { nil }
-#                 let(:expected_version) { '12.19.33' }
-
-#                 it_behaves_like 'a correct package info'
-#               end
-#             end
-#           end
-#         end
-#       end
-
-#       context 'for current' do
-#         let(:channel) { 'current' }
-
-#         context 'for solaris2' do
-#           let(:platform) { 'solaris2' }
-
-#           context 'for 5.11' do
-#             let(:platform_version) { '5.11' }
-
-#             context 'for sun4v' do
-#               let(:architecture) { 'sun4v' }
-#               let(:expected_architecture) { 'sparc' }
-
-#               context 'without a version' do
-#                 let(:project_version) { nil }
-#                 let(:expected_version) { latest_current_chef }
-
-#                 it_behaves_like 'a correct package info'
-#               end
-#             end
-#           end
-#         end
-#       end
-#     end
-
-#     context 'for chef-workstation' do
-#       let(:project) { "chef-workstation" }
-
-#       context 'for stable' do
-#         let(:channel) { 'stable' }
-
-#         context 'for windows' do
-#           let(:platform) { 'windows' }
-
-#           context 'for 2008r2' do
-#             let(:platform_version) { '2008r2' }
-#             let(:expected_platform_version) { '11' }
-
-#             context 'for x86_64' do
-#               let(:architecture) { 'x86_64' }
-
-#               context 'without a version' do
-#                 let(:project_version) { nil }
-#                 let(:expected_version) { latest_stable_chef_workstation }
-
-#                 it_behaves_like 'a correct package info'
-#               end
-#             end
-#           end
-#         end
-#       end
-
-#       context 'for current' do
-#         let(:channel) { 'current' }
-
-#         context 'for mac_os_x' do
-#           let(:platform) { 'mac_os_x' }
-
-#           context 'for 12' do
-#             let(:platform_version) { '12' }
-
-#             context 'for x86_64' do
-#               let(:architecture) { 'x86_64' }
-
-#               context 'without a version' do
-#                 let(:project_version) { nil }
-#                 let(:expected_version) { latest_current_chef_workstation }
-
-#                 it_behaves_like 'a correct package info'
-#               end
-#             end
-#           end
-#         end
-#       end
-#     end
-
-#     context 'for chef-server' do
-#       let(:project) { "chef-server" }
-
-#       context 'for stable' do
-#         let(:channel) { 'stable' }
-
-#         context 'for el' do
-#           let(:platform) { 'el' }
-
-#           context 'for 7' do
-#             let(:platform_version) { '7' }
-
-#             context 'for x86_64' do
-#               let(:architecture) { 'x86_64' }
-
-#               context 'without a version' do
-#                 let(:project_version) { nil }
-#                 let(:expected_version) { latest_stable_chef_server }
-
-#                 it_behaves_like 'a correct package info'
-#               end
-#             end
-#           end
-#         end
-#       end
-#     end
-
-#     context 'for angrychef' do
-#       let(:project) { "angrychef" }
-
-#       context 'for stable' do
-#         let(:channel) { 'stable' }
-
-#         context 'for debian' do
-#           let(:platform) { 'debian' }
-
-#           context 'for 6' do
-#             let(:platform_version) { '6' }
-
-#             context 'for x86_64' do
-#               let(:architecture) { 'x86_64' }
-
-#               context 'without a version' do
-#                 let(:project_version) { nil }
-#                 let(:expected_version) { '12.18.31' }
-
-#                 it_behaves_like 'a correct package info'
-#               end
-#             end
-#           end
-#         end
-#       end
-
-#       context 'for stable' do
-#         let(:channel) { 'stable' }
-
-#         context 'for freebsd' do
-#           let(:platform) { 'freebsd' }
-
-#           context 'for 10' do
-#             let(:platform_version) { '10' }
-
-#             context 'for amd64' do
-#               let(:architecture) { 'amd64' }
-#               let(:expected_architecture) { 'x86_64' }
-
-#               context 'without a version' do
-#                 let(:project_version) { nil }
-#                 let(:expected_version) { '15.0.293' }
-
-#                 it_behaves_like 'a correct package info'
-#               end
-#             end
-#           end
-#         end
-#       end
-#     end
-
-#     # We need to return all versions of 64-bit artifacts on stable channel
-#     # except chef after a specific version.
-#     context "for AngryChef 64-bit artifacts" do
-#       let(:project) { "angrychef" }
-#       let(:channel) { 'stable' }
-#       let(:platform) { 'windows' }
-#       let(:platform_version) { '2008r2' }
-#       let(:architecture) { 'x86_64' }
-#       let(:project_version) { '12.9.38' }
-
-#       it_behaves_like 'a correct package info'
-#     end
-
-#   # end
-
-#   context '/<CHANNEL>/<PROJECT>/packages endpoint' do
-#     real_projects.each do |project|
-#       context "for #{project}" do
-#         let(:endpoint){ "/stable/#{project}/packages" }
-
-#         it "exists" do
-#           get(endpoint)
-#           expect(last_response).to be_ok
-#         end
-
-#         it "returns the correct JSON data" do
-#           get(endpoint)
-#           expect(last_response.header['Content-Type']).to include 'application/json'
-#           response = JSON.parse(last_response.body)
-#           # automate/delivery manifests are identical. latest artifacts will always be automate
-#           project = 'automate' if project == 'delivery'
-#           expect(last_response.body).to match(project) unless response.empty?
-#         end
-#       end
-#     end
-
-#     context "for stable chefdk" do
-#       let(:endpoint) { '/stable/chefdk/packages' }
-#       let(:params) { { v: version } }
-#       let(:versions_output) {
-#         get(endpoint, params)
-#         metadata_json = last_response.body
-#         JSON.parse(metadata_json)
-#       }
-
-#       [ nil, 'latest'].each do |version|
-#         context "with version #{version.inspect}" do
-#           let(:version) { version }
-
-#           it 'returns the latest version for each platform, platform_version and architecture' do
-#             expect(versions_output.keys.length).to eq(6)
-
-#             versions_output.each do |p, data|
-#               data.each do |pv, data|
-#                 data.each do |m, metadata|
-#                   expect(metadata['sha1']).to match /^[0-9a-f]{40}$/
-#                   expect(metadata['sha256']).to match /^[0-9a-f]{64}$/
-#                   expect(metadata['url']).to match 'http'
-#                   expect(metadata['version']).to eq(latest_stable_chefdk)
-#                 end
-#               end
-#             end
-#           end
-#         end
-#       end
-
-#       context 'with version 0.6' do
-#         let(:version) { '0.6' }
-
-#         it 'returns the latest starting with 0.6 for each platform, platform_version and architecture' do
-#           expect(versions_output.keys.length).to eq(5)
-
-#           versions_output.each do |p, data|
-#             data.each do |pv, data|
-#               data.each do |m, metadata|
-#                 expect(metadata['sha1']).to match /^[0-9a-f]{40}$/
-#                 expect(metadata['sha256']).to match /^[0-9a-f]{64}$/
-#                 expect(metadata['url']).to match 'http'
-#                 # 0.6.2 is the latest on the 0.6.X series
-#                 expect(metadata['version']).to eq('0.6.2')
-#               end
-#             end
-#           end
-#         end
-#       end
-
-#       context 'with version 0.7.0' do
-#         let(:version) { '0.7.0' }
-
-#         it 'returns version 0.7.0 for each platform, platform_version and architecture' do
-#           expect(versions_output.keys.length).to eq(5)
-
-#           versions_output.each do |p, data|
-#             data.each do |pv, data|
-#               data.each do |m, metadata|
-#                 expect(metadata['sha1']).to match /^[0-9a-f]{40}$/
-#                 expect(metadata['sha256']).to match /^[0-9a-f]{64}$/
-#                 expect(metadata['url']).to match 'http'
-#                 # We expect the exact version here
-#                 expect(metadata['version']).to eq('0.7.0')
-#               end
-#             end
-#           end
-#         end
-#       end
-#     end
-
-#     context "for current chef-workstation" do
-#       let(:endpoint) { '/current/chef-workstation/packages' }
-#       let(:params) { { v: version } }
-#       let(:versions_output) {
-#         get(endpoint, params)
-#         metadata_json = last_response.body
-#         JSON.parse(metadata_json)
-#       }
-#     end
-#   end
-
-#   context '/<CHANNEL>/<PROJECT>/versions/all endpoint' do
-#     real_projects.each do |project|
-#       context "for #{project}" do
-#         let(:endpoint){ "/stable/#{project}/versions/all" }
-
-#         it "exists" do
-#           get(endpoint)
-#           expect(last_response).to be_ok
-#         end
-
-#         it "returns the correct JSON data" do
-#           get(endpoint)
-#           expect(last_response.header['Content-Type']).to include 'application/json'
-#           response = JSON.parse(last_response.body)
-#           expect(response).to be_an_instance_of(Array)
-#           expect(response.length).to be > 1
-#         end
-#       end
-#     end
-#   end
-
-#   context '/<CHANNEL>/<PROJECT>/versions/latest endpoint' do
-#     real_projects.each do |project|
-#       context "for #{project}" do
-#         let(:endpoint){ "/stable/#{project}/versions/latest" }
-
-#         it "exists" do
-#           get(endpoint)
-#           expect(last_response).to be_ok
-#         end
-
-#         it "returns the correct JSON data" do
-#           get(endpoint)
-#           expect(last_response.header['Content-Type']).to include 'application/json'
-#           response = JSON.parse(last_response.body)
-#           expect(response).to be_an_instance_of(String)
-#         end
-#       end
-#     end
-#   end
-
-#   context "install script" do
-#     %w(
-#       sh
-#       ps1
-#     ).each do |extension|
-#       context "/install.#{extension}" do
-#         let(:install_script) { "/install.#{extension}" }
-#         it "exists" do
-#           get install_script
-#           expect(last_response).to be_ok
-#         end
-#       end
-#     end
-
-#     context "unknown extension" do
-#       it "returns a 404" do
-#         get "/stable/chef/install.poop"
-#         expect(last_response).to be_not_found
-#       end
-#     end
-#   end
-
-#   context "/_status" do
-#     let(:endpoint){"/_status"}
-#     let(:expected_timestamp) do
-#       JSON.parse(File.read(File.join(SPEC_DATA, "stable/chef-manifest.json")))["run_data"]["timestamp"]
-#     end
-
-#     it "exists" do
-#       get endpoint
-#       expect(last_response).to be_ok
-#     end
-
-#     it "returns JSON data" do
-#       get endpoint
-#       expect(last_response.header['Content-Type']).to include 'application/json'
-#     end
-
-#     it "returns the timestamp of the last poller run" do
-#       get endpoint
-#       expect(JSON.parse(last_response.body)["timestamp"]).to eq(expected_timestamp)
-#     end
-#   end
-
-#   context "legacy behavior" do
-#     let(:prerelease){ nil }
-#     let(:nightlies){ nil }
-
-#     let(:params) do
-#       params = {}
-#       params[:p] = 'ubuntu'
-#       params[:pv] = '18.04'
-#       params[:m] = 'x86_64'
-#       params[:prerelease] = prerelease unless prerelease.nil? # could be false, explicitly
-#       params[:nightlies] = nightlies unless nightlies.nil?    # could be false, explicitly
-#       params
-#     end
-
-#     %w(
-#       nightlies
-#       prerelease
-#     ).each do |legacy_param|
-
-#       context "#{legacy_param} param" do
-#         let(:endpoint) { '/metadata' }
-#         let(legacy_param.to_sym) { true }
-
-#         it "returns a package from the current channel" do
-#           get(endpoint, params)
-#           expect(last_response.body).to match("https://packages.chef.io/files/current")
-#         end
-#       end
-
-#     end
-
-#     {
-#       '/download' => spec_data_record('stable', 'chef', 'ubuntu', '18.04', 'x86_64', latest_stable_chef)['url'],
-#       '/download-server' => spec_data_record('stable', 'chef-server', 'ubuntu', '18.04', 'x86_64', latest_stable_chef_server)['url'],
-#       '/chef/download-server' => spec_data_record('stable', 'chef-server', 'ubuntu', '18.04', 'x86_64', latest_stable_chef_server)['url'],
-#       '/metadata' => spec_data_record('stable', 'chef', 'ubuntu', '18.04', 'x86_64', latest_stable_chef).merge({ 'version' => latest_stable_chef }),
-#       '/metadata-server' => spec_data_record('stable', 'chef-server', 'ubuntu', '18.04', 'x86_64', latest_stable_chef_server).merge({ 'version' => latest_stable_chef_server }),
-#       '/chef/metadata-server' => spec_data_record('stable', 'chef-server', 'ubuntu', '18.04', 'x86_64', latest_stable_chef_server).merge({ 'version' => latest_stable_chef_server }),
-#       '/chef/install.msi' => 'http://example.org/stable/chef/download?p=windows&pv=2008r2&m=i386',
-#       '/install.msi' => 'http://example.org/stable/chef/download?p=windows&pv=2008r2&m=i386',
-#       '/full_client_list' => nil,
-#       '/full_list' => nil,
-#       '/full_server_list' => nil,
-#       '/chef/full_client_list' => nil,
-#       '/chef/full_list' => nil,
-#       '/chef/full_server_list' => nil,
-#       '/chef_platform_names' => nil,
-#       '/chef_server_platform_names' => nil,
-#       '/chef/chef_platform_names' => nil,
-#       '/chef/chef_server_platform_names' => nil,
-#       '/full_chefdk_list' => nil,
-#       '/full_server_list' => nil,
-#     }.each do |legacy_endpoint, response_match_data|
-
-#       context "legacy endpoint #{legacy_endpoint}" do
-#         let(:endpoint) { legacy_endpoint }
-
-#         it "returns the correct response data" do
-#           get(endpoint, params)
-
-#           if legacy_endpoint =~ /download/ || legacy_endpoint =~ /install\.msi/
-#             follow_redirect!
-#             expect(last_request.url).to match(response_match_data)
-#           elsif legacy_endpoint =~ /metadata/
-#             parsed_metadata = last_response.body.lines.inject({}) do |metadata, line|
-#               key, value = line.strip.split("\t")
-#               metadata[key] = value
-#               metadata
-#             end
-
-#             expect(parsed_metadata['version']).to eq(response_match_data['version'])
-#             expect(parsed_metadata['url']).to eq(response_match_data['url'])
-#             expect(parsed_metadata['sha256']).to eq(response_match_data['sha256'])
-#             expect(parsed_metadata['sha1']).to eq(response_match_data['sha1'])
-#           elsif legacy_endpoint =~ /platform_names/
-#             # we check that response is valid JSON.
-#             expect{JSON.parse(last_response.body)}.not_to raise_error
-#           else
-#             parsed_json = JSON.parse(last_response.body)
-
-#             # we check a certain hash structure that needs to be present in these endpoints
-#             parsed_json.each do |platform, data|
-#               data.each do |platform_version, data|
-#                 data.each do |architecture, metadata|
-#                   expect(metadata['url']).to be_a(String)
-#                   expect(metadata['sha1']).to be_a(String)
-#                   expect(metadata['sha256']).to be_a(String)
-#                   expect(metadata['version']).to be_a(String)
-#                 end
-#               end
-#             end
-
-#           end
-#         end
-
-#       end
-#     end
-#   end
-# # end
+#--
+# Author:: Tyler Cloke (tyler@opscode.com)
+# Author:: Stephen Delano (stephen@opscode.com)
+# Author:: Seth Chisamore (sethc@opscode.com)
+# Author:: Lamont Granquist (lamont@opscode.com)
+# Copyright:: Copyright (c) 2010-2024 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+require 'uri'
+
+context 'Omnitruck' do
+  def app
+    Omnitruck
+  end
+
+  # Accept: application/json is required for all metadata/JSON endpoints because
+  # the metadata endpoint checks request.accept?('text/plain') and responds with
+  # plain text when the Accept header matches (including the default */*).
+  JSON_ACCEPT = { 'HTTP_ACCEPT' => 'application/json' }.freeze
+
+  # ---------------------------------------------------------------------------
+  # Info / status endpoints
+  # ---------------------------------------------------------------------------
+
+  describe 'GET /products' do
+    it 'returns a JSON array of known products' do
+      get '/products'
+      expect(last_response).to be_ok
+      expect(last_response.content_type).to include('application/json')
+      products = JSON.parse(last_response.body)
+      expect(products).to be_an(Array)
+      expect(products).to include('chef', 'chef-workstation', 'chefdk', 'inspec')
+    end
+  end
+
+  describe 'GET /platforms' do
+    it 'returns a JSON hash of supported platforms' do
+      get '/platforms'
+      expect(last_response).to be_ok
+      expect(last_response.content_type).to include('application/json')
+      platforms = JSON.parse(last_response.body)
+      expect(platforms).to be_a(Hash)
+      expect(platforms['ubuntu']).to eq('Ubuntu Linux')
+      expect(platforms['windows']).to eq('Windows')
+      expect(platforms['el']).to eq('Red Hat Enterprise Linux/CentOS')
+      expect(platforms['mac_os_x']).to eq('macOS')
+    end
+  end
+
+  describe 'GET /architectures' do
+    it 'returns a JSON array of supported architectures' do
+      get '/architectures'
+      expect(last_response).to be_ok
+      expect(last_response.content_type).to include('application/json')
+      archs = JSON.parse(last_response.body)
+      expect(archs).to be_an(Array)
+      expect(archs).not_to be_empty
+      expect(archs).to include('x86_64')
+    end
+  end
+
+  describe 'GET /_healthz' do
+    it 'returns 204 No Content' do
+      get '/_healthz'
+      expect(last_response.status).to eq(204)
+    end
+  end
+
+  describe 'GET /_version' do
+    it 'returns version information as JSON' do
+      get '/_version'
+      expect(last_response).to be_ok
+      data = JSON.parse(last_response.body)
+      expect(data['version']).to match(/\d+\.\d+\.\d+/)
+    end
+  end
+
+  describe 'GET /_status' do
+    it 'returns a timestamp JSON from the stable chef manifest' do
+      get '/_status'
+      expect(last_response).to be_ok
+      expect(last_response.content_type).to include('application/json')
+      data = JSON.parse(last_response.body)
+      expect(data).to have_key('timestamp')
+      expect(data['timestamp']).to eq('2024-09-14 06:26:34 -0400')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Metadata endpoint
+  # ---------------------------------------------------------------------------
+
+  describe 'GET /stable/chef/metadata' do
+    let(:el7_params) { { p: 'el', pv: '7', m: 'x86_64' } }
+
+    context 'with el/7/x86_64, no version specified' do
+      it 'returns JSON metadata for the latest stable chef version' do
+        get '/stable/chef/metadata', el7_params, JSON_ACCEPT
+        expect(last_response).to be_ok
+        expect(last_response.content_type).to include('application/json')
+        data = JSON.parse(last_response.body)
+        expect(data['version']).to eq(latest_stable_chef)
+        expect(data['url']).to include('/stable/chef/')
+        expect(data['url']).to include('/el/7/')
+        expect(data['sha256']).not_to be_nil
+        expect(data['sha256']).not_to be_empty
+        expect(data['sha1']).not_to be_nil
+        expect(data['sha1']).not_to be_empty
+      end
+
+      it 'returns plain-text metadata when Accept: text/plain' do
+        get '/stable/chef/metadata', el7_params, 'HTTP_ACCEPT' => 'text/plain'
+        expect(last_response).to be_ok
+        parsed = last_response.body.lines.inject({}) do |h, line|
+          k, v = line.strip.split("\t")
+          h[k] = v unless k.nil?
+          h
+        end
+        expect(parsed['version']).to eq(latest_stable_chef)
+        expect(parsed['url']).to include('/stable/chef/')
+        expect(parsed['sha256']).not_to be_empty
+        expect(parsed['sha1']).not_to be_empty
+      end
+    end
+
+    context 'with an explicit version' do
+      it 'returns metadata for the specified version' do
+        get '/stable/chef/metadata', el7_params.merge(v: latest_stable_chef), JSON_ACCEPT
+        expect(last_response).to be_ok
+        data = JSON.parse(last_response.body)
+        expect(data['version']).to eq(latest_stable_chef)
+      end
+    end
+
+    context 'with ubuntu 20.04/x86_64' do
+      it 'returns a .deb package URL' do
+        get '/stable/chef/metadata', { p: 'ubuntu', pv: '20.04', m: 'x86_64' }, JSON_ACCEPT
+        expect(last_response).to be_ok
+        data = JSON.parse(last_response.body)
+        expect(data['url']).to include('ubuntu')
+        expect(data['url']).to end_with('.deb')
+      end
+    end
+
+    context 'with windows 2019/x86_64' do
+      it 'returns a .msi package URL' do
+        get '/stable/chef/metadata', { p: 'windows', pv: '2019', m: 'x86_64' }, JSON_ACCEPT
+        expect(last_response).to be_ok
+        data = JSON.parse(last_response.body)
+        expect(data['url']).to include('windows')
+        expect(data['url']).to end_with('.msi')
+      end
+    end
+
+    context 'with sles 12/x86_64 (native SLES build threshold exceeded)' do
+      it 'returns a native SLES package URL' do
+        get '/stable/chef/metadata', { p: 'sles', pv: '12', m: 'x86_64' }, JSON_ACCEPT
+        expect(last_response).to be_ok
+        data = JSON.parse(last_response.body)
+        expect(data['url']).not_to be_empty
+        expect(data['url']).to include('sles')
+      end
+    end
+
+    context 'with an invalid version' do
+      it 'returns 404' do
+        get '/stable/chef/metadata', el7_params.merge(v: '0.0.0'), JSON_ACCEPT
+        expect(last_response.status).to eq(404)
+      end
+    end
+
+    context 'with an invalid platform' do
+      it 'returns 404' do
+        get '/stable/chef/metadata', { p: 'fakeos', pv: '99', m: 'x86_64' }, JSON_ACCEPT
+        expect(last_response.status).to eq(404)
+      end
+    end
+
+    context 'with explicit stable channel and prerelease=true' do
+      it 'still uses the stable channel from the explicit URL segment' do
+        get '/stable/chef/metadata', el7_params.merge(prerelease: 'true'), JSON_ACCEPT
+        expect(last_response).to be_ok
+        data = JSON.parse(last_response.body)
+        expect(data['version']).to eq(latest_stable_chef)
+      end
+    end
+  end
+
+  describe 'GET /current/chef/metadata' do
+    let(:el7_params) { { p: 'el', pv: '7', m: 'x86_64' } }
+
+    it 'returns metadata from the current channel' do
+      get '/current/chef/metadata', el7_params, JSON_ACCEPT
+      expect(last_response).to be_ok
+      data = JSON.parse(last_response.body)
+      expect(data['version']).to eq(latest_current_chef)
+      expect(data['url']).to include('/current/chef/')
+    end
+  end
+
+  describe 'GET /chef/metadata (no explicit channel)' do
+    let(:el7_params) { { p: 'el', pv: '7', m: 'x86_64' } }
+
+    it 'defaults to stable channel when no prerelease param is given' do
+      get '/chef/metadata', el7_params, JSON_ACCEPT
+      expect(last_response).to be_ok
+      data = JSON.parse(last_response.body)
+      expect(data['version']).to eq(latest_stable_chef)
+    end
+
+    it 'uses current channel when prerelease=true is given' do
+      get '/chef/metadata', el7_params.merge(prerelease: 'true'), JSON_ACCEPT
+      expect(last_response).to be_ok
+      data = JSON.parse(last_response.body)
+      expect(data['version']).to eq(latest_current_chef)
+    end
+
+    it 'uses current channel when nightlies=true is given' do
+      get '/chef/metadata', el7_params.merge(nightlies: 'true'), JSON_ACCEPT
+      expect(last_response).to be_ok
+      data = JSON.parse(last_response.body)
+      expect(data['version']).to eq(latest_current_chef)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Download endpoint
+  # ---------------------------------------------------------------------------
+
+  describe 'GET /stable/chef/download' do
+    let(:el7_params) { { p: 'el', pv: '7', m: 'x86_64' } }
+
+    it 'redirects to the el/7 package URL' do
+      get '/stable/chef/download', el7_params
+      expect(last_response).to be_redirect
+      expect(last_response.location).to include('/stable/chef/')
+      expect(last_response.location).to include('/el/7/')
+    end
+
+    it 'redirects ubuntu packages to .deb URLs' do
+      get '/stable/chef/download', { p: 'ubuntu', pv: '20.04', m: 'x86_64' }
+      expect(last_response).to be_redirect
+      expect(last_response.location).to include('ubuntu')
+      expect(last_response.location).to end_with('.deb')
+    end
+
+    it 'normalizes i686 to i386 for windows packages (32-bit URL)' do
+      get '/stable/chef/download', { p: 'windows', pv: '2019', m: 'i686' }
+      expect(last_response).to be_redirect
+      # Windows 32-bit packages use x86 in the filename (not x86_64)
+      expect(last_response.location).to include('windows')
+      expect(last_response.location).to end_with('.msi')
+      expect(last_response.location).not_to include('x86_64')
+    end
+
+    it 'normalizes arm64 to aarch64 for linux packages' do
+      get '/stable/chef/download', { p: 'ubuntu', pv: '20.04', m: 'arm64' }
+      expect(last_response).to be_redirect
+      # Ubuntu arm64 packages use arm64 in the filename (manifest key is aarch64)
+      expect(last_response.location).to include('ubuntu')
+      expect(last_response.location).to end_with('.deb')
+      expect(last_response.location).to include('arm64')
+    end
+
+    context 'with an invalid version' do
+      it 'returns 404' do
+        get '/stable/chef/download', el7_params.merge(v: '0.0.0')
+        expect(last_response.status).to eq(404)
+      end
+    end
+
+    context 'with an invalid platform' do
+      it 'returns 404' do
+        get '/stable/chef/download', { p: 'fakeos', pv: '99', m: 'x86_64' }
+        expect(last_response.status).to eq(404)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Packages endpoint
+  # ---------------------------------------------------------------------------
+
+  describe 'GET /stable/chef/packages' do
+    it 'returns a nested JSON package list' do
+      get '/stable/chef/packages'
+      expect(last_response).to be_ok
+      expect(last_response.content_type).to include('application/json')
+      data = JSON.parse(last_response.body)
+      expect(data).to be_a(Hash)
+      expect(data).to have_key('el')
+      expect(data['el']).to have_key('7')
+      expect(data['el']['7']).to have_key('x86_64')
+      pkg = data['el']['7']['x86_64']
+      expect(pkg).to have_key('url')
+      expect(pkg).to have_key('sha256')
+      expect(pkg).to have_key('version')
+    end
+
+    it 'returns a flattened JSON package list with flatten=true' do
+      get '/stable/chef/packages', { flatten: 'true' }
+      expect(last_response).to be_ok
+      data = JSON.parse(last_response.body)
+      expect(data).to be_a(Hash)
+      # Flattened: each platform value is an array of package hashes
+      first_platform_pkgs = data.values.first
+      expect(first_platform_pkgs).to be_an(Array)
+      first_pkg = first_platform_pkgs.first
+      expect(first_pkg).to have_key('url')
+      expect(first_pkg).to have_key('platform_version')
+      expect(first_pkg).to have_key('architecture')
+    end
+  end
+
+  describe 'GET /current/chef/packages' do
+    it 'returns packages from the current channel' do
+      get '/current/chef/packages'
+      expect(last_response).to be_ok
+      data = JSON.parse(last_response.body)
+      expect(data).to be_a(Hash)
+      expect(data).to have_key('el')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Versions endpoints (stubs Mixlib::Install to avoid network calls)
+  # ---------------------------------------------------------------------------
+
+  describe 'GET /stable/chef/versions/all' do
+    before do
+      allow(Mixlib::Install).to receive(:available_versions)
+        .with('chef', 'stable')
+        .and_return(['18.3.0', '18.4.0', '18.5.0'])
+    end
+
+    it 'returns all available versions as a JSON array' do
+      get '/stable/chef/versions/all'
+      expect(last_response).to be_ok
+      expect(last_response.content_type).to include('application/json')
+      data = JSON.parse(last_response.body)
+      expect(data).to eq(['18.3.0', '18.4.0', '18.5.0'])
+    end
+  end
+
+  describe 'GET /stable/chef/versions/latest' do
+    before do
+      allow(Mixlib::Install).to receive(:available_versions)
+        .with('chef', 'stable')
+        .and_return(['18.3.0', '18.4.0', '18.5.0'])
+    end
+
+    it 'returns the latest version as a JSON string' do
+      get '/stable/chef/versions/latest'
+      expect(last_response).to be_ok
+      data = JSON.parse(last_response.body)
+      expect(data).to eq('18.5.0')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Amazon Linux 2 URL rewriting
+  # ---------------------------------------------------------------------------
+
+  describe 'Amazon Linux 2 URL rewriting' do
+    context 'chef on amazon/2 (metadata)' do
+      it 'remaps internally to el/7 packages' do
+        get '/stable/chef/metadata', { p: 'amazon', pv: '2', m: 'x86_64' }, JSON_ACCEPT
+        expect(last_response).to be_ok
+        data = JSON.parse(last_response.body)
+        # chef on amazon/2 is remapped to el/7 in get_package_info
+        expect(data['url']).to include('/el/7/')
+      end
+    end
+
+    context 'chef on amazon/2 (download)' do
+      it 'redirects to an el/7 package URL' do
+        get '/stable/chef/download', { p: 'amazon', pv: '2', m: 'x86_64' }
+        expect(last_response).to be_redirect
+        expect(last_response.location).to include('/el/7/')
+      end
+    end
+
+    context 'chef-workstation on amazon/2 (metadata)' do
+      it 'rewrites the amazon/2 URL to el/7 in the response' do
+        get '/stable/chef-workstation/metadata', { p: 'amazon', pv: '2', m: 'x86_64' }, JSON_ACCEPT
+        expect(last_response).to be_ok
+        data = JSON.parse(last_response.body)
+        # URL is rewritten from /amazon/2/ to /el/7/ for chef-workstation
+        expect(data['url']).to include('/el/7/')
+        expect(data['url']).not_to include('/amazon/2/')
+      end
+    end
+
+    context 'chef-workstation on amazon/2 (download)' do
+      it 'redirects to an el/7 URL' do
+        get '/stable/chef-workstation/download', { p: 'amazon', pv: '2', m: 'x86_64' }
+        expect(last_response).to be_redirect
+        expect(last_response.location).to include('/el/7/')
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # SLES platform remapping
+  # ---------------------------------------------------------------------------
+
+  describe 'SLES platform handling' do
+    context 'with sles/12/x86_64 and latest chef (above native-build threshold)' do
+      it 'serves native SLES packages without remapping to EL' do
+        get '/stable/chef/metadata', { p: 'sles', pv: '12', m: 'x86_64' }, JSON_ACCEPT
+        expect(last_response).to be_ok
+        data = JSON.parse(last_response.body)
+        expect(data['url']).to include('sles')
+        expect(data['url']).not_to include('/el/')
+      end
+    end
+
+    context 'with sles/11/x86_64 and a version below the native-build threshold' do
+      it 'remaps to EL packages for pre-native-build versions' do
+        # 12.0.3 < SLES_PROJECT_VERSIONS["chef"] (12.21.1) => remaps to EL
+        # sles pv 11 <= 11 maps to el/5
+        get '/stable/chef/metadata', { p: 'sles', pv: '11', m: 'x86_64', v: '12.0.3' }, JSON_ACCEPT
+        expect(last_response).to be_ok
+        data = JSON.parse(last_response.body)
+        expect(data['url']).to include('/el/')
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Legacy redirects
+  # ---------------------------------------------------------------------------
+
+  describe 'legacy redirects' do
+    it 'GET /download passes through to /chef/download' do
+      get '/download', { p: 'el', pv: '7', m: 'x86_64' }
+      expect(last_response).to be_redirect
+    end
+
+    it 'GET /metadata passes through to /chef/metadata and returns JSON' do
+      get '/metadata', { p: 'el', pv: '7', m: 'x86_64' }, JSON_ACCEPT
+      expect(last_response).to be_ok
+      data = JSON.parse(last_response.body)
+      expect(data).to have_key('url')
+    end
+
+    it 'GET /download-server passes through to /chef-server/download' do
+      get '/download-server', { p: 'el', pv: '7', m: 'x86_64' }
+      expect(last_response).to be_redirect
+    end
+
+    it 'GET /metadata-server passes through to /chef-server/metadata' do
+      get '/metadata-server', { p: 'el', pv: '7', m: 'x86_64' }, JSON_ACCEPT
+      expect(last_response).to be_ok
+      data = JSON.parse(last_response.body)
+      expect(data).to have_key('url')
+    end
+
+    it 'GET /full_client_list passes through to /chef/packages' do
+      get '/full_client_list'
+      expect(last_response).to be_ok
+      expect(last_response.content_type).to include('application/json')
+    end
+
+    it 'GET /full_server_list passes through to /chef-server/packages' do
+      get '/full_server_list'
+      expect(last_response).to be_ok
+      expect(last_response.content_type).to include('application/json')
+    end
+
+    it 'GET /chef_platform_names returns platforms JSON (via direct legacy redirect to /platforms)' do
+      # /chef_platform_names is in the legacy hash: '/chef_platform_names' => '/platforms'
+      # It calls /platforms directly (not via /chef/platforms), so returns 200 with JSON
+      get '/chef_platform_names'
+      expect(last_response).to be_ok
+      data = JSON.parse(last_response.body)
+      expect(data).to have_key('ubuntu')
+      expect(data).to have_key('windows')
+    end
+
+    it 'GET /chef/metadata-chefdk passes through to /chefdk/metadata' do
+      get '/chef/metadata-chefdk', { p: 'el', pv: '7', m: 'x86_64' }, JSON_ACCEPT
+      expect(last_response).to be_ok
+      data = JSON.parse(last_response.body)
+      expect(data['url']).to include('chefdk')
+    end
+
+    it 'GET /install.msi redirects to a windows download URL' do
+      get '/install.msi'
+      expect(last_response).to be_redirect
+      expect(last_response.location).to include('download')
+      expect(last_response.location).to include('windows')
+    end
+
+    it 'GET /chef/install.msi redirects to a windows download URL' do
+      get '/chef/install.msi'
+      expect(last_response).to be_redirect
+      expect(last_response.location).to include('download')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Multiple projects
+  # ---------------------------------------------------------------------------
+
+  describe 'GET /stable/chefdk/metadata' do
+    it 'returns chefdk package metadata for the latest stable version' do
+      get '/stable/chefdk/metadata', { p: 'el', pv: '7', m: 'x86_64' }, JSON_ACCEPT
+      expect(last_response).to be_ok
+      data = JSON.parse(last_response.body)
+      expect(data['url']).to include('chefdk')
+      expect(data['version']).to eq(latest_stable_chefdk)
+    end
+  end
+
+  describe 'GET /stable/inspec/metadata' do
+    it 'returns inspec package metadata' do
+      get '/stable/inspec/metadata', { p: 'el', pv: '7', m: 'x86_64' }, JSON_ACCEPT
+      expect(last_response).to be_ok
+      data = JSON.parse(last_response.body)
+      expect(data['url']).to include('inspec')
+    end
+  end
+
+  describe 'GET /stable/chef-workstation/metadata' do
+    it 'returns chef-workstation metadata for the latest stable version' do
+      get '/stable/chef-workstation/metadata', { p: 'el', pv: '7', m: 'x86_64' }, JSON_ACCEPT
+      expect(last_response).to be_ok
+      data = JSON.parse(last_response.body)
+      expect(data['url']).to include('chef-workstation')
+      expect(data['version']).to eq(latest_stable_chef_workstation)
+    end
+  end
+end

--- a/spec/chef/cache_spec.rb
+++ b/spec/chef/cache_spec.rb
@@ -1,20 +1,144 @@
-require 'spec_helper'
-require 'tmpdir'
+#--
+# Copyright:: Copyright (c) 2016-2024 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
-# describe Chef::Cache do
-#   let(:cache_path) { Dir.mktmpdir }
-#   after { FileUtils.rm_rf(cache_path) }
-#
-#   it "can update the cache from package router" do
-#     Chef::Cache.new(cache_path).update
-#
-#     Chef::Cache::KNOWN_CHANNELS.each do |channel|
-#       Chef::Cache::KNOWN_PROJECTS.each do |project|
-#         manifest_path = File.join(cache_path, channel, "#{project}-manifest.json")
-#         expect(File.exist?(manifest_path)).to be(true)
-#
-#         expect(JSON.parse(File.read(manifest_path))["run_data"]["timestamp"]).to be_a(String)
-#       end
-#     end
-#   end
-# end
+require 'spec_helper'
+
+describe Chef::Cache do
+  subject(:cache) { described_class.new }
+
+  # ---------------------------------------------------------------------------
+  # KNOWN_PROJECTS and KNOWN_CHANNELS constants
+  # ---------------------------------------------------------------------------
+
+  describe '::KNOWN_PROJECTS' do
+    it 'is a non-empty array' do
+      expect(described_class::KNOWN_PROJECTS).to be_an(Array)
+      expect(described_class::KNOWN_PROJECTS).not_to be_empty
+    end
+
+    it 'includes core Chef products' do
+      expect(described_class::KNOWN_PROJECTS).to include('chef', 'chef-workstation', 'chefdk', 'inspec')
+    end
+  end
+
+  describe '::KNOWN_CHANNELS' do
+    it 'includes stable, current and unstable' do
+      expect(described_class::KNOWN_CHANNELS).to contain_exactly('current', 'stable', 'unstable')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # manifest_for
+  # ---------------------------------------------------------------------------
+
+  describe '#manifest_for' do
+    context 'with a valid project and channel (stable/chef)' do
+      it 'returns a parsed JSON hash' do
+        result = cache.manifest_for('chef', 'stable')
+        expect(result).to be_a(Hash)
+      end
+
+      it 'contains platform top-level keys' do
+        result = cache.manifest_for('chef', 'stable')
+        expect(result.keys).to include('el', 'ubuntu', 'debian')
+      end
+
+      it 'contains run_data with a timestamp' do
+        result = cache.manifest_for('chef', 'stable')
+        expect(result['run_data']).to be_a(Hash)
+        expect(result['run_data']['timestamp']).to eq('2024-09-14 06:26:34 -0400')
+      end
+
+      it 'contains nested platform/version/arch/version_str package info' do
+        result = cache.manifest_for('chef', 'stable')
+        el7_x86 = result.dig('el', '7', 'x86_64')
+        expect(el7_x86).to be_a(Hash)
+        expect(el7_x86).not_to be_empty
+        # Each version entry has sha1, sha256, url
+        version_entry = el7_x86.values.first
+        expect(version_entry).to have_key('sha1')
+        expect(version_entry).to have_key('sha256')
+        expect(version_entry).to have_key('url')
+      end
+    end
+
+    context 'with a valid project and channel (current/chef)' do
+      it 'returns a parsed JSON hash for the current channel' do
+        result = cache.manifest_for('chef', 'current')
+        expect(result).to be_a(Hash)
+        expect(result.keys).to include('el')
+      end
+
+      it 'contains run_data with the current channel timestamp' do
+        result = cache.manifest_for('chef', 'current')
+        expect(result['run_data']['timestamp']).to eq('2024-09-14 08:01:51 -0400')
+      end
+    end
+
+    context 'with a valid project and channel (stable/chefdk)' do
+      it 'returns a non-empty hash for chefdk' do
+        result = cache.manifest_for('chefdk', 'stable')
+        expect(result).to be_a(Hash)
+        expect(result).not_to be_empty
+      end
+    end
+
+    context 'with a project that has no fixture file' do
+      # MockRedis returns nil when the file does not exist, which causes
+      # manifest_for to raise MissingManifestFile.
+      it 'raises MissingManifestFile' do
+        expect {
+          cache.manifest_for('nonexistent-project-xyz', 'stable')
+        }.to raise_error(Chef::Cache::MissingManifestFile)
+      end
+
+      it 'includes the project and channel in the error message' do
+        expect {
+          cache.manifest_for('nonexistent-project-xyz', 'stable')
+        }.to raise_error(Chef::Cache::MissingManifestFile, /nonexistent-project-xyz.*stable/)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # last_modified_for
+  # ---------------------------------------------------------------------------
+
+  describe '#last_modified_for' do
+    context 'with a valid project and channel (stable/chef)' do
+      it 'returns the timestamp string from run_data' do
+        result = cache.last_modified_for('chef', 'stable')
+        expect(result).to eq('2024-09-14 06:26:34 -0400')
+      end
+    end
+
+    context 'with a valid project and channel (current/chef)' do
+      it 'returns the correct timestamp for the current channel' do
+        result = cache.last_modified_for('chef', 'current')
+        expect(result).to eq('2024-09-14 08:01:51 -0400')
+      end
+    end
+
+    context 'with a project that has no fixture file' do
+      it 'raises MissingManifestFile' do
+        expect {
+          cache.last_modified_for('nonexistent-project-xyz', 'stable')
+        }.to raise_error(Chef::Cache::MissingManifestFile)
+      end
+    end
+  end
+end

--- a/spec/install_scripts_spec.rb
+++ b/spec/install_scripts_spec.rb
@@ -21,8 +21,7 @@ describe 'Omnitruck Install Scripts' do
         get '/install.sh', { license_id: 'test-license-123' }
         expect(last_response).to be_ok
         expect(last_response.body).to include('#!/bin/sh')
-        expect(last_response.body).to include('# License ID provided via context')
-        expect(last_response.body).to include("license_id='test-license-123'")
+        expect(last_response.body).to include('license_id="test-license-123"')
       end
     end
 
@@ -31,7 +30,28 @@ describe 'Omnitruck Install Scripts' do
         get '/install.sh'
         expect(last_response).to be_ok
         expect(last_response.body).to include('#!/bin/sh')
-        expect(last_response.body).not_to include('# License ID provided via context')
+        # Should have the parameter definition but no default value
+        expect(last_response.body).to include('L)  license_id="$OPTARG"')
+        expect(last_response.body).not_to match(/^license_id="[^$]/m)
+      end
+    end
+
+    context 'with base_url parameter' do
+      it 'includes base_url in the generated script' do
+        get '/install.sh', { base_url: 'https://custom.chef.io' }
+        expect(last_response).to be_ok
+        expect(last_response.body).to include('#!/bin/sh')
+        expect(last_response.body).to include('base_api_url="https://custom.chef.io"')
+      end
+    end
+
+    context 'with both license_id and base_url parameters' do
+      it 'includes both in the generated script' do
+        get '/install.sh', { license_id: 'test-license-123', base_url: 'https://custom.chef.io' }
+        expect(last_response).to be_ok
+        expect(last_response.body).to include('#!/bin/sh')
+        expect(last_response.body).to include('license_id="test-license-123"')
+        expect(last_response.body).to include('base_api_url="https://custom.chef.io"')
       end
     end
   end
@@ -48,8 +68,7 @@ describe 'Omnitruck Install Scripts' do
       it 'includes license_id in the generated script' do
         get '/install.ps1', { license_id: 'trial-license-456' }
         expect(last_response).to be_ok
-        expect(last_response.body).to include('# License ID provided via context')
-        expect(last_response.body).to include("install -license_id 'trial-license-456'")
+        expect(last_response.body).to include('$license_id = \'trial-license-456\'')
       end
     end
 
@@ -57,7 +76,27 @@ describe 'Omnitruck Install Scripts' do
       it 'does not include license_id in install command' do
         get '/install.ps1'
         expect(last_response).to be_ok
-        expect(last_response.body).not_to include('# License ID provided via context')
+        # Should have the parameter definition but no default value
+        expect(last_response.body).to include('[string]')
+        expect(last_response.body).to include('$license_id')
+        expect(last_response.body).not_to include("$license_id = '")
+      end
+    end
+
+    context 'with base_url parameter' do
+      it 'includes base_url in the generated script' do
+        get '/install.ps1', { base_url: 'https://custom.chef.io' }
+        expect(last_response).to be_ok
+        expect(last_response.body).to include('$base_server_uri = "https://custom.chef.io"')
+      end
+    end
+
+    context 'with both license_id and base_url parameters' do
+      it 'includes both in the generated script' do
+        get '/install.ps1', { license_id: 'trial-license-456', base_url: 'https://custom.chef.io' }
+        expect(last_response).to be_ok
+        expect(last_response.body).to include('$license_id = \'trial-license-456\'')
+        expect(last_response.body).to include('$base_server_uri = "https://custom.chef.io"')
       end
     end
   end

--- a/spec/install_scripts_spec.rb
+++ b/spec/install_scripts_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+require 'rack/test'
+
+describe 'Omnitruck Install Scripts' do
+  include Rack::Test::Methods
+
+  def app
+    Omnitruck
+  end
+
+  describe 'GET /install.sh' do
+    it 'returns install.sh script' do
+      get '/install.sh'
+      expect(last_response).to be_ok
+      expect(last_response.body).to include('#!/bin/sh')
+      expect(last_response.body).to include('while getopts')
+    end
+
+    context 'with license_id parameter' do
+      it 'includes license_id in the generated script' do
+        get '/install.sh', { license_id: 'test-license-123' }
+        expect(last_response).to be_ok
+        expect(last_response.body).to include('#!/bin/sh')
+        expect(last_response.body).to include('# License ID provided via context')
+        expect(last_response.body).to include("license_id='test-license-123'")
+      end
+    end
+
+    context 'without license_id parameter' do
+      it 'does not include license_id pre-set in script' do
+        get '/install.sh'
+        expect(last_response).to be_ok
+        expect(last_response.body).to include('#!/bin/sh')
+        expect(last_response.body).not_to include('# License ID provided via context')
+      end
+    end
+  end
+
+  describe 'GET /install.ps1' do
+    it 'returns install.ps1 script' do
+      get '/install.ps1'
+      expect(last_response).to be_ok
+      expect(last_response.body).to include('function Install-Project')
+      expect(last_response.body).to include('Get-ProjectMetadata')
+    end
+
+    context 'with license_id parameter' do
+      it 'includes license_id in the generated script' do
+        get '/install.ps1', { license_id: 'trial-license-456' }
+        expect(last_response).to be_ok
+        expect(last_response.body).to include('# License ID provided via context')
+        expect(last_response.body).to include("install -license_id 'trial-license-456'")
+      end
+    end
+
+    context 'without license_id parameter' do
+      it 'does not include license_id in install command' do
+        get '/install.ps1'
+        expect(last_response).to be_ok
+        expect(last_response.body).not_to include('# License ID provided via context')
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -134,6 +134,8 @@ class MockRedis
   # fixtures in the data/ directory
   def get(key)
     File.read(File.join(SPEC_DATA, "#{key}-manifest.json"))
+  rescue Errno::ENOENT
+    nil
   end
 
   def set(key, value)


### PR DESCRIPTION
## Description

Adding license_id parameter to install scripts call so that omnitruck-service can pass license_id as needed and remove the need for separate templates in omnitruck-service. This makes mixlib-install the source of truth for install script generation and consolidates similar code being in multiple repos

## Related PR's
https://github.com/chef/mixlib-install/pull/416
https://github.com/chef/omnitruck-service/pull/130


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
