### PR TITLE
CHEF-30517 Update and standardize copyright notices to Progress Software Corporation - copyright_update

### DIFF
--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,0 +1,1 @@
+Copyright (c) 2012-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.

--- a/README.md
+++ b/README.md
@@ -232,7 +232,6 @@ We use Architectural Decision Records to document important architectural decisi
 
 ## License
 
-- Copyright:: Copyright (c) 2010-2019 Chef Software, Inc.
 - License:: Apache License, Version 2.0
 
 ```text
@@ -247,3 +246,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+# Copyright
+
+See [COPYRIGHT.md](./COPYRIGHT.md).

--- a/app.rb
+++ b/app.rb
@@ -3,7 +3,7 @@
 # Author:: Stephen Delano (stephen@opscode.com)
 # Author:: Seth Chisamore (sethc@opscode.com)
 # Author:: Lamont Granquist (lamont@opscode.com)
-# Copyright:: Copyright (c) 2010-2017 Chef Software, Inc.
+# Copyright:: Copyright (c) 2012-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/cache.rb
+++ b/lib/chef/cache.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2016 Chef Software, Inc.
+# Copyright:: Copyright (c) 2012-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/version.rb
+++ b/lib/chef/version.rb
@@ -3,7 +3,7 @@
 # Author:: Stephen Delano (stephen@opscode.com)
 # Author:: Seth Chisamore (sethc@opscode.com)
 # Author:: Lamont Granquist (lamont@opscode.com)
-# Copyright:: Copyright (c) 2010-2013 Chef Software, Inc.
+# Copyright:: Copyright (c) 2012-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/version/incomplete.rb
+++ b/lib/chef/version/incomplete.rb
@@ -3,7 +3,7 @@
 # Author:: Stephen Delano (stephen@opscode.com)
 # Author:: Seth Chisamore (sethc@opscode.com)
 # Author:: Lamont Granquist (lamont@opscode.com)
-# Copyright:: Copyright (c) 2010-2013 Chef Software, Inc.
+# Copyright:: Copyright (c) 2012-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -3,7 +3,7 @@
 # # Author:: Stephen Delano (stephen@opscode.com)
 # # Author:: Seth Chisamore (sethc@opscode.com)
 # # Author:: Lamont Granquist (lamont@opscode.com)
-# # Copyright:: Copyright (c) 2010-2013 Chef Software, Inc.
+# # Copyright:: Copyright (c) 2012-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # # License:: Apache License, Version 2.0
 # #
 # # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@
 # Author:: Stephen Delano (stephen@opscode.com)
 # Author:: Seth Chisamore (sethc@opscode.com)
 # Author:: Lamont Granquist (lamont@opscode.com)
-# Copyright:: Copyright (c) 2010-2013 Chef Software, Inc.
+# Copyright:: Copyright (c) 2012-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This is an automated message using the copyright-automator tool.

This PR updates copyright notices from Chef Software and Opscode to Progress Software Corporation as part of the repository standardization effort.

## Automated Changes

- Updated Opscode, Chef, and Progress copyright notices to use Progress Software Corporation current language
- Applied year range: 2012-2026 reflecting our understanding of repo-specific activity
- Preserved original formatting and comment styles

## Manual Changes Required

⚠️ This PR requires manual intervention for the following files:

- `COPYRIGHT.md:1` - adjust-copyright-file
- `README.md:1` - adjust-readme
- `README.md:235` - adjust-readme

Please review these locations and make appropriate manual edits.

## No Other Changes Intended

- No change to Author, Contributor, or Maintainer information
- No change to non-PSC copyright holders
