### PR TITLE
pin docker api version to 1.44 to fix docker build error

### DIFF
--- a/.expeditor/build.docker.yml
+++ b/.expeditor/build.docker.yml
@@ -1,4 +1,5 @@
 image_registry: chefes
 env:
   VERSION: "0.2.0"
+  DOCKER_API_VERSION: "1.44"
 dobi_file: dobi.yaml


### PR DESCRIPTION
This pull request makes a small change to the `.expeditor/build.docker.yml` file by setting the `DOCKER_API_VERSION` environment variable to `"1.44"`. This helps ensure compatibility with newer Docker features.<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
